### PR TITLE
feat(etcd-client): support getting full directories, improve watcher

### DIFF
--- a/packages/etcd-client/src/index.ts
+++ b/packages/etcd-client/src/index.ts
@@ -40,7 +40,7 @@ export function connect(srv: string): Promise<void> {
 /**
  * Get the provided key eg. /foo/bar
  * @param {string}            key         path to the key in ETCD
- * @return {Promise<string>} resolves with string if OK, rejects with any error
+ * @return {Promise<T>} resolves with string if OK, rejects with any error
  */
 export function get<T>(key: string): Promise<T> {
   return new Promise((resolve, reject) => {
@@ -58,10 +58,14 @@ export function get<T>(key: string): Promise<T> {
 /**
  * Watch the provided key eg. /foo/bar and also get the initial value
  * @param {string}            key         path to the key in ETCD
- * @param {IEtcdClientError, string) =>  void}  callback    function to be called when the value is available/has changed
+ * @param {IEtcdClientError, T) =>  void}  callback    function to be called when the value is available/has changed
  */
-export function watch<T>(key: string, interval = 60 * 1000, callback: (error: Error | null, value: T | null) => void): () => void {
-  let timeout;
+export function watch<T>(
+  key: string,
+  interval = 60 * 1000,
+  callback: (error: Error | null, value: T | null) => void
+): () => void {
+  let timeout: NodeJS.Timeout;
   const getWatchedKey = () => {
     get<T>(key).then(
       value => {
@@ -77,5 +81,5 @@ export function watch<T>(key: string, interval = 60 * 1000, callback: (error: Er
   getWatchedKey();
   return () => {
     clearTimeout(timeout);
-  }
+  };
 }


### PR DESCRIPTION
Previously the etcd-client would only return keys with values, eg. `/imagedeliveryservice/origin/baseUrl`.
Now it also supports getting full directories, eg. `/imagedeliveryservice`.

If the key is found to be a directory it will return the directory in normal json format:
```
{
  origin: {
    accessParameters: '',
    baseUrl: 'https://rbmorigin.blob.core.windows.net/'
  },
  settings: {
    webp: { qualityPercent: '65' },
    jpeg: { qualityPercent: '70' },
    png: { qualityPercent: '70' }
  }
}
```