### PR TITLE
fix: enhanced analytics data in play response

### DIFF
--- a/packages/exposure/src/index.ts
+++ b/packages/exposure/src/index.ts
@@ -35,7 +35,6 @@ export {
   DRM,
   Format,
   Stitcher,
-  CdnProvider,
   StreamInfo,
   Sprite,
   ContractRestrictions

--- a/packages/exposure/src/models/play-model.ts
+++ b/packages/exposure/src/models/play-model.ts
@@ -19,13 +19,6 @@ export enum Stitcher {
   NOWTILUS = "NOWTILUS"
 }
 
-export enum CdnProvider {
-  LUMEN = "CTL",
-  HIGHWINDS = "HW",
-  FASTLY = "FSLY",
-  UNKNOWN = "unknown"
-}
-
 export class DRM {
   licenseServerUrl: string;
   certificateUrl?: string;
@@ -148,7 +141,7 @@ export class Cdn {
   @jsonProperty()
   public host?: string;
   @jsonProperty()
-  public provider?: CdnProvider;
+  public provider?: string;
 }
 
 export class Analytics {


### PR DESCRIPTION
Mentioning new params
https://empdev.slack.com/archives/C01KJG3CGHF/p1617789890039200

Analytics specification https://tools.cloud.ebms.ericsson.net/confluence/pages/viewpage.action?spaceKey=INTDOC&title=Analytics+Event+Specification

In Exposure prestage https://pscloud.ott.ebsd.ericsson.net:447/#!/Entitlements/playV2

```
  "cdn": {
    "profile": "",
    "host": "",
    "provider": ""
  },
  "analytics": {
    "postInterval": 0,
    "bucket": 0,
    "tag": ""
  }
  ```