### PR TITLE
feat: add option to override authHeader for changeEmail

### DIFF
--- a/packages/exposure/src/services/user-service.ts
+++ b/packages/exposure/src/services/user-service.ts
@@ -68,6 +68,7 @@ export interface ChangeEmailAndUsername extends CustomerAndBusinessUnitOptions {
 
 export interface ChangeEmailOptions extends CustomerAndBusinessUnitOptions {
   newEmailAddress: string;
+  authHeader?: () => { Authorization: string };
 }
 
 export class UserService extends BaseService {
@@ -247,7 +248,7 @@ export class UserService extends BaseService {
     ).then(data => deserialize(LoginResponse, data));
   }
 
-  public changeEmail({ newEmailAddress, customer, businessUnit }: ChangeEmailOptions) {
+  public changeEmail({ newEmailAddress, customer, businessUnit, authHeader }: ChangeEmailOptions) {
     return this.put(
       `${this.cuBuUrl({
         apiVersion: "v3",
@@ -257,7 +258,7 @@ export class UserService extends BaseService {
       {
         newEmailAddress
       },
-      this.options.authHeader()
+      authHeader?.() ?? this.options.authHeader()
     );
   }
 


### PR DESCRIPTION
Add option to override authHeader for change email since we won't be able to store the token in localStorage until we've added the email so the web app can't fetch any data because of reasons.