### PR TITLE
feat: assetId added in the play response model

### DIFF
--- a/packages/exposure/src/models/play-model.ts
+++ b/packages/exposure/src/models/play-model.ts
@@ -155,6 +155,8 @@ export class Analytics {
 
 export class Play {
   @jsonProperty()
+  public assetId?: string;
+  @jsonProperty()
   public accountId: string;
   @jsonProperty()
   public productId: string;


### PR DESCRIPTION
For some customers we will use the external id for the play requests, then the internal one is needed for use in other APIs.