### PR TITLE
feat: add exposureUrl to app config

### DIFF
--- a/packages/whitelabel/src/interfaces/wl-config.ts
+++ b/packages/whitelabel/src/interfaces/wl-config.ts
@@ -43,9 +43,12 @@ export interface IAppConfig {
  */
 /**
  * @typedef IApiConfig
+ * @property {string} exposureUrl
  * @property {IApiConfigSearch} search
+ * @property {IApiConfigTVLogin} tvLogin
  */
 export interface IApiConfig {
+  exposureUrl: string;
   search: {
     internalUrl: string;
   };


### PR DESCRIPTION
Either we add it here, or we add it to WLSystemConfig. Any opinions?