### PR TITLE
feat: add IImage appLogo

### DIFF
--- a/packages/whitelabel/src/interfaces/wl-config.ts
+++ b/packages/whitelabel/src/interfaces/wl-config.ts
@@ -93,7 +93,7 @@ export interface IParameters {
  * @property {IConfigHomePage} homePage
  * @property {string} title
  * @property {WLMenuItem[]} menu
- * @property {IImage} appLogo - optional
+ * @property {IImage[]} images
  * @property {string} logo - optional
  * @property {string} backgroundImage - optional
  * @property {WLSystemConfig} systemConfig
@@ -113,7 +113,7 @@ export interface IWLConfig {
   title: string;
   description: string;
   menu: IWLMenuItem[];
-  appLogo?: IImage;
+  images: IImage[];
   logo?: string;
   favicon?: string;
   backgroundImage?: string;

--- a/packages/whitelabel/src/models/wl-config.ts
+++ b/packages/whitelabel/src/models/wl-config.ts
@@ -10,7 +10,7 @@ import {
   IContactInformation,
   IParameters
 } from "../interfaces/wl-config";
-import { jsonProperty, SystemConfig } from "@ericssonbroadcastservices/exposure-sdk";
+import { IImage, jsonProperty, SystemConfig } from "@ericssonbroadcastservices/exposure-sdk";
 
 export const breakpoints = {
   mobile: "600px",
@@ -124,6 +124,8 @@ export class WLConfig implements IWLConfig {
   public menu: WLMenuItem[];
   @jsonProperty()
   public logo: string;
+  @jsonProperty({ type: Object })
+  public images: IImage[];
   @jsonProperty()
   public favicon?: string;
   @jsonProperty()


### PR DESCRIPTION
When working on react-native I realised that it's a log easier to work with images if they have height and width set, hence this. 