### PR TITLE
feat: rename carousel 'description' to 'subTitle'

### DIFF
--- a/packages/whitelabel/src/interfaces/wl-carousel.ts
+++ b/packages/whitelabel/src/interfaces/wl-carousel.ts
@@ -10,7 +10,7 @@ export interface IWLCarousel {
   type: string;
   subType: CarouselSubType | null;
   title?: string;
-  description?: string;
+  subTitle?: string;
   assets: IWLCarouselItem[];
   tagTitles?: IWLTagTitles;
 }

--- a/packages/whitelabel/src/models/wl-component.ts
+++ b/packages/whitelabel/src/models/wl-component.ts
@@ -36,7 +36,7 @@ export class WLCarousel extends WLComponent implements IWLCarousel {
   @jsonProperty()
   public title: string;
   @jsonProperty()
-  public description?: string;
+  public subTitle?: string;
   @jsonProperty({ type: String })
   public subType: CarouselSubType | null;
   @jsonProperty({ type: WLAsset })


### PR DESCRIPTION
Might have done this right on master, but routines are there to follow