### PR TITLE
fix: parse iso8601 to include year

### DIFF
--- a/packages/whitelabel/src/utils/time.ts
+++ b/packages/whitelabel/src/utils/time.ts
@@ -81,7 +81,7 @@ export function iso8601ToReadableString(iso8601String: string, translations: Tra
   const hours = duration.hours;
   const minutes = duration.minutes;
 
-  const yearText = years > 1 ? translations.getText(["DATES", "YEAR"]) : translations.getText(["DATES", "YEAR"]);
+  const yearText = translations.getText(["DATES", "YEAR"]);
   const monthText = months > 1 ? translations.getText(["DATES", "MONTHS"]) : translations.getText(["DATES", "MONTH"]);
   const dayText = days > 1 ? translations.getText(["DATES", "DAYS"]) : translations.getText(["DATES", "DAY"]);
   const hourText = hours > 1 ? translations.getText(["DATES", "HOURS"]) : translations.getText(["DATES", "HOUR"]);


### PR DESCRIPTION
![Screenshot 2021-12-08 083222](https://user-images.githubusercontent.com/624182/145560058-6e4ff50b-eb36-4811-ad7d-53be29defb28.png)
