### PR TITLE
fix: always refetch authorized components

### DIFF
--- a/packages/whitelabel-react/demo/index.tsx
+++ b/packages/whitelabel-react/demo/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { DeviceType, IDeviceInfo } from "@ericssonbroadcastservices/exposure-sdk";
 import { DeviceGroup } from "@ericssonbroadcastservices/whitelabel-sdk";
-import { RedBeeProvider, IStorage } from "../src/index";
+import { RedBeeProvider, IStorage, useConfig } from "../src/index";
 import { LanguageSelector } from "./components/LanguageSelector";
 import SearchInput from "./components/SearchInput";
 import { Routes, Route, HashRouter, Link } from "react-router-dom";
@@ -20,12 +20,13 @@ const device: IDeviceInfo = {
 };
 
 export default function App() {
+  const [config] = useConfig();
   return (
     <div>
       <HashRouter>
         <Menu />
         <div style={{ display: "flex", justifyContent: "space-evenly" }}>
-          <Link to="/">
+          <Link to={`/page/${config?.homePage.id}`}>
             <button style={{ marginRight: "10px" }}>Home</button>
           </Link>
           <LanguageSelector />

--- a/packages/whitelabel-react/src/hooks/usePage.ts
+++ b/packages/whitelabel-react/src/hooks/usePage.ts
@@ -104,7 +104,7 @@ export function useResolvedPage(pageId: string, pageType: PageType): TApiHook<IR
     (page?.components || []).map(reference => {
       return {
         retry: false,
-        staleTime: 1000 * 60 * 10,
+        staleTime: reference.authorized ? 0 : 1000 * 60 * 10,
         refetchInterval: reference.reloadInterval,
         queryKey: [
           selectedLanguage,


### PR DESCRIPTION
This should ensure that favourites are updated after following/unfollowing an asset, and it will also make the contiunue watching carousel up to date. 

An alternative approach would be to programmatically clear the cache of those carousels at the appropriate event, which would be more efficient in terms of request count, but less clean. 