### PR TITLE
fix: cache component based on entitre reference

### DIFF
--- a/packages/whitelabel-react/src/hooks/usePage.ts
+++ b/packages/whitelabel-react/src/hooks/usePage.ts
@@ -110,7 +110,7 @@ export function useResolvedPage(pageId: string, pageType: PageType): TApiHook<IR
         queryKey: [
           selectedLanguage,
           reference.id,
-          reference.presentation.layout,
+          reference.presentation,
           reference.internalUrl,
           reference.authorized ? userSession?.sessionToken : null,
           reference?.subType === WLComponentSubType.TAG_FEED_QUERY ? tagList?.query : null


### PR DESCRIPTION
Currently react-query caches components on presentation.layout. It should be cached on the entire presentation.