### PR TITLE
fix: rename season and episode properties

### DIFF
--- a/packages/whitelabel/src/interfaces/wl-carousel-item.ts
+++ b/packages/whitelabel/src/interfaces/wl-carousel-item.ts
@@ -63,8 +63,8 @@ export interface IWLCarouselItem {
   tags: IWLAssetTag[];
   tvShowId?: string;
   channelId?: string;
-  season?: number;
-  episode?: number;
+  seasonNumber?: number;
+  episodeNumber?: number;
   externalReferences: ExternalReferences[];
   action: IWLAction;
   year: number;

--- a/packages/whitelabel/src/models/wl-asset.ts
+++ b/packages/whitelabel/src/models/wl-asset.ts
@@ -61,9 +61,9 @@ export class WLAsset implements IWLCarouselItem {
   @jsonProperty()
   public channelId: string;
   @jsonProperty()
-  public season: number;
+  public seasonNumber?: number;
   @jsonProperty()
-  public episode?: number;
+  public episodeNumber?: number;
   @jsonProperty({ type: WLParticipant })
   public participants: WLParticipant[] = [];
   @jsonProperty()
@@ -174,6 +174,7 @@ export class WLAsset implements IWLCarouselItem {
    * @deprecated routing logic should preferably be kept in apps
    */
   public getPlayLink = (userEntitlements: Product[], availabilityKeys: string[]) => {
+    // TODO: remove this once we consider it safe.
     switch (this.type) {
       case AssetType.TV_SHOW:
         return `/asset/${this.getIdentifier()}`;
@@ -182,7 +183,7 @@ export class WLAsset implements IWLCarouselItem {
           ? `/play/${this.getIdentifier()}?playlist=season`
           : `/asset/${this.getIdentifier()}`;
       default:
-        if (this.tvShowId && this.season) {
+        if (this.tvShowId && this.seasonNumber) {
           return this.getIsEntitled(availabilityKeys)
             ? `/play/${this.getIdentifier()}?playlist=season`
             : `/asset/${this.getIdentifier()}`;


### PR DESCRIPTION
Long story... But the iOS app has for some reason implemented properties for season and episode as string, which means that when I added season and episode to whitelabelinternalapi all iOS applications crashed. This is my proposed work around.