### PR TITLE
chore: revert unwanted removal of property

### DIFF
--- a/packages/whitelabel/src/interfaces/wl-carousel-item.ts
+++ b/packages/whitelabel/src/interfaces/wl-carousel-item.ts
@@ -65,6 +65,14 @@ export interface IWLCarouselItem {
   channelId?: string;
   seasonNumber?: number;
   episodeNumber?: number;
+  /**
+   * @deprecated use seasonNumber
+   */
+  season?: number;
+  /**
+   * @deprecated use episodeNumber
+   */
+  episode?: number;
   externalReferences: ExternalReferences[];
   action: IWLAction;
   year: number;

--- a/packages/whitelabel/src/models/wl-asset.ts
+++ b/packages/whitelabel/src/models/wl-asset.ts
@@ -64,6 +64,16 @@ export class WLAsset implements IWLCarouselItem {
   public seasonNumber?: number;
   @jsonProperty()
   public episodeNumber?: number;
+  /**
+   * @deprecated use seasonNumber
+   */
+  @jsonProperty()
+  public season: number;
+  /**
+   * @deprecated use episodeNumber
+   */
+  @jsonProperty()
+  public episode?: number;
   @jsonProperty({ type: WLParticipant })
   public participants: WLParticipant[] = [];
   @jsonProperty()


### PR DESCRIPTION
I chickened out when I saw that whitelabelinternalapi actually implemented the season-property.