### PR TITLE
fix: use exposure baseUrl for wl requests

### DIFF
--- a/packages/whitelabel-react/demo/index.tsx
+++ b/packages/whitelabel-react/demo/index.tsx
@@ -56,7 +56,6 @@ const storage: IStorage = {
 function AppProvider() {
   return (
     <RedBeeProvider
-      internalApiUrl={"https://bsbu.enigmatv.io"}
       exposureBaseUrl={"https://exposure.api.redbee.dev"}
       customer={"BSCU"}
       businessUnit={"BSBU"}

--- a/packages/whitelabel-react/src/InitialPropsProvider.tsx
+++ b/packages/whitelabel-react/src/InitialPropsProvider.tsx
@@ -15,7 +15,6 @@ interface IInitialPropsProvider {
   exposureBaseUrl: string;
   device: IDeviceInfo;
   children?: React.ReactNode;
-  internalApiUrl: string;
   deviceGroup: DeviceGroup;
   onSessionValidationError?: (err: unknown) => void;
 }
@@ -82,7 +81,6 @@ export function InitialPropsProvider({
   businessUnit,
   exposureBaseUrl,
   device,
-  internalApiUrl,
   deviceGroup,
   onSessionValidationError
 }: IInitialPropsProvider) {
@@ -123,7 +121,6 @@ export function InitialPropsProvider({
         storage: storage || null,
         device,
         exposureBaseUrl,
-        internalApiUrl,
         config: null,
         deviceGroup,
         exposureApi,
@@ -134,7 +131,7 @@ export function InitialPropsProvider({
           deviceGroup,
           customer,
           businessUnit,
-          baseUrl: internalApiUrl
+          baseUrl: exposureBaseUrl
         })
       });
       setIsReady(true);

--- a/packages/whitelabel-react/src/RedBeeProvider.tsx
+++ b/packages/whitelabel-react/src/RedBeeProvider.tsx
@@ -16,7 +16,6 @@ export interface IRedBeeState {
   customer: string;
   businessUnit: string;
   exposureBaseUrl: string;
-  internalApiUrl: string;
   deviceGroup: DeviceGroup;
   exposureApi: ExposureApi;
   whiteLabelApi: WhiteLabelService;
@@ -87,7 +86,7 @@ function reducer(state: IRedBeeState, action: TAction): IRedBeeState {
         // The only time we need to update the exposure api is when setting a new session
         exposureApi,
         whiteLabelApi: new WhiteLabelService({
-          baseUrl: state.internalApiUrl,
+          baseUrl: state.exposureBaseUrl,
           customer: state.customer,
           businessUnit: state.businessUnit,
           deviceGroup: state.deviceGroup,
@@ -134,7 +133,6 @@ interface IRedBeeProvider {
   customer: string;
   businessUnit: string;
   exposureBaseUrl: string;
-  internalApiUrl: string;
   children?: React.ReactNode;
   deviceGroup: DeviceGroup;
   storage?: IStorage;
@@ -171,7 +169,6 @@ export function RedBeeProvider({
   businessUnit,
   device,
   deviceGroup,
-  internalApiUrl,
   exposureBaseUrl,
   children,
   autoFetchConfig,
@@ -180,8 +177,8 @@ export function RedBeeProvider({
   if (!customer || !businessUnit) {
     throw "customer and businessUnit are required";
   }
-  if (!exposureBaseUrl || !internalApiUrl || !deviceGroup || !device) {
-    throw `Missing required prop in RedBeeProvider. You provided: exposureBaseUrl: ${exposureBaseUrl}, internalApiUrl: ${internalApiUrl}, deviceGroup: ${deviceGroup}, device: ${device}`;
+  if (!exposureBaseUrl || !deviceGroup || !device) {
+    throw `Missing required prop in RedBeeProvider. You provided: exposureBaseUrl: ${exposureBaseUrl}, deviceGroup: ${deviceGroup}, device: ${device}`;
   }
   if (!storage) {
     console.warn("not providing a storage module means no data will be persisted between sessions");
@@ -193,7 +190,6 @@ export function RedBeeProvider({
       businessUnit={businessUnit}
       device={device}
       deviceGroup={deviceGroup}
-      internalApiUrl={internalApiUrl}
       exposureBaseUrl={exposureBaseUrl}
       onSessionValidationError={onSessionValidationError}
     >

--- a/packages/whitelabel-react/src/hooks/useEntitlementForAsset.spec.tsx
+++ b/packages/whitelabel-react/src/hooks/useEntitlementForAsset.spec.tsx
@@ -37,8 +37,7 @@ function TestWrapper({ children }) {
   return (
     <RedBeeProvider
       deviceGroup={DeviceGroup.WEB}
-      exposureBaseUrl="internal"
-      internalApiUrl="exposure"
+      exposureBaseUrl="exposure"
       device={mockDevice}
       customer={"CU"}
       businessUnit={"BU"}


### PR DESCRIPTION
We no longer need a distinction between internaApiUrl and exposureUrl. Hence removing it here. 

The only consumer of this package is white-label-native-tv, so this should be fine even though this has a breaking change in IRedBeeState and RedBeeProvider.