### PR TITLE
feat: expose EPG

### DIFF
--- a/packages/exposure/src/interfaces/entitlement/play.ts
+++ b/packages/exposure/src/interfaces/entitlement/play.ts
@@ -147,7 +147,7 @@ export interface IPlay {
   playSessionId: string;
   playToken: string;
   playTokenExpiration: number;
-  epg: IEpg;
+  epg?: IEpg;
   formats: IFormat[];
   streamInfo: IStreamInfo;
   sprites?: ISprite[];


### PR DESCRIPTION
Exposes the flags implemented in EMP-19054. I couldn't actually find a spec for them there, but in the last demo they were demonstrated like this, and the play response has them:

![Screenshot from 2023-01-24 22-37-13](https://user-images.githubusercontent.com/515120/214426513-309e57bc-df4a-4706-8cdc-872be796f235.png)

The `IEpg` interface might not need to be exported and could be defined directly on `IPlay` (like `bookmarks`), but I though this way is the safest for avoiding having to make further changes.