### PR TITLE
feat: optional time parameter to getEntitlementForAsset

### DIFF
--- a/packages/exposure/src/services/entitlement-service.ts
+++ b/packages/exposure/src/services/entitlement-service.ts
@@ -61,8 +61,7 @@ export class EntitlementService extends BaseService {
       searchParams.set("paymentProvider", paymentProvider);
     }
     if (time) {
-      // Add one millisecond because time needs to be after publication time
-      searchParams.set("time", new Date(time.getTime() + 1).toISOString());
+      searchParams.set("time", time.toISOString());
     }
     return this.get(
       `${this.cuBuUrl({


### PR DESCRIPTION
As per the swagger API docs stating time is an optional string query param "The time to be used when checking entitlement".

I don't know the type of date format they expect. That's not in the swagger API. So maybe we want to change it to take date as input later on so we can format it here.