### PR TITLE
fix: OnNowAsset sometimes missing asset property

### DIFF
--- a/packages/exposure/src/models/program-model.ts
+++ b/packages/exposure/src/models/program-model.ts
@@ -38,7 +38,7 @@ export class OnNowAsset {
   @jsonProperty({
     type: Asset
   })
-  public asset: Asset;
+  public asset?: Asset;
 }
 
 export class OnNowResponse {


### PR DESCRIPTION
OnNowAsset is used for virtual channels. It sometimes has this property, but not always. For example my tag-based virtual channel doesn't have it:

![Screenshot from 2023-02-02 14-19-40](https://user-images.githubusercontent.com/515120/216335857-0470bb9d-ea44-4bfd-be8a-260a89ae97f5.png)

I also tested with Eyevinns tag based streaming tech virtual channels created 2 years ago. And they did have the asset key.