### PR TITLE
fix: migrate to userdetails 2 endpoint

### DIFF
--- a/packages/exposure/src/services/user-service.ts
+++ b/packages/exposure/src/services/user-service.ts
@@ -26,9 +26,9 @@ export interface SetNewPasswordOptions extends CustomerAndBusinessUnitOptions {
 
 export interface UpdateUserDetailsOptions extends CustomerAndBusinessUnitOptions {
   body: {
-    displayName: string | null;
-    newPassword: string | null;
-    language: string | null;
+    displayName?: string | null;
+    newPassword?: string | null;
+    language?: string | null;
   };
 }
 
@@ -149,7 +149,7 @@ export class UserService extends BaseService {
   public updateUserDetails({ customer, businessUnit, body }: UpdateUserDetailsOptions) {
     return this.put(
       `${this.cuBuUrl({
-        apiVersion: "v1",
+        apiVersion: "v2",
         customer,
         businessUnit
       })}/user/details`,


### PR DESCRIPTION
userdetails v1 endpoint is deprecated, might as well move away from it. Kept the string | null typing to be backwards compatible.