### PR TITLE
feat(EMP-19650): add `getAppConfig()` to customer-config-service

### DIFF
--- a/packages/exposure/src/index.ts
+++ b/packages/exposure/src/index.ts
@@ -16,10 +16,11 @@ import {
   TPaymentProvider
 } from "./services/payment-service";
 import { SystemService } from "./services/system-service";
+import { PreferencesService } from "./services/preferences-service";
+import { WhiteLabelService } from "./services/white-label-service";
 
 /* Models */
 import { SystemConfig } from "./models/system-config-model";
-import { PreferencesService } from "./services/preferences-service";
 
 export { ILocalizedMetadata, ILocalizedMetadata as Localized } from "./interfaces/content/localized-metadata";
 export { ImageOrientation, ImageType, IImage, IImage as ImageModel } from "./interfaces/content/image";
@@ -98,6 +99,7 @@ export {
 export { ITag, ITag as TagResponse } from "./interfaces/tag/tag";
 export { IBookmark, IBookmark as Bookmark } from "./interfaces/content/bookmark";
 export { CustomerConfigFile } from "./models/customer-config-file-model";
+export { AppConfig } from "./models/app-config-model";
 export { Program, EpgResponse, OnNowAsset } from "./models/program-model";
 export {
   IPurchase,
@@ -128,7 +130,7 @@ export {
   LoginMethodType,
   AccessModel,
   SignupModel,
-  ISystemConfig,
+  ISystemConfig
 } from "./interfaces/config/system-config";
 export { AspectRatio } from "./interfaces/aspect-ratio";
 export { ApiError } from "./models/api-error-model";
@@ -153,7 +155,8 @@ export {
   PaymentService,
   CustomerConfigService,
   DocumentService,
-  PreferencesService
+  PreferencesService,
+  WhiteLabelService
 };
 export { EntitlementService, TPlayDrm, TPlayFormat, TAdDeviceType } from "./services/entitlement-service";
 
@@ -204,4 +207,5 @@ export class ExposureApi {
   public payment = new PaymentService(this.options);
   public preferences = new PreferencesService(this.options);
   public system = new SystemService(this.options);
+  public whiteLabel = new WhiteLabelService(this.options);
 }

--- a/packages/exposure/src/models/app-config-model.ts
+++ b/packages/exposure/src/models/app-config-model.ts
@@ -1,0 +1,50 @@
+interface SamsungConfig {
+  appName: string;
+  appIdentifier: string;
+  images: {
+    splashScreenImage: string;
+    appIcon: string;
+  };
+}
+
+interface LGConfig {
+  appName: string;
+  appIdentifier: string;
+  tileBackgroundColor: string;
+  images: {
+    splashScreenImage: string;
+    appIcon: string;
+  };
+}
+
+interface TvOSConfig {
+  teamId: string;
+  teamName: string;
+  itcTeamId: string;
+  appName: string;
+  appIdentifier: string;
+  splashColor: string;
+  images: {
+    appIconBackgroundImage: string;
+    appIcon: string;
+    topShelfImage: string;
+  };
+}
+
+interface AndroidConfig {
+  appName: string;
+  appIdentifier: string;
+  splashColor: string;
+  images: {
+    splashScreenImage: string;
+    appIcon: string;
+    tvBannerIcon: string;
+  };
+}
+
+export interface AppConfig {
+  Samsung: SamsungConfig;
+  LG: LGConfig;
+  tvOS: TvOSConfig;
+  android: AndroidConfig;
+}

--- a/packages/exposure/src/services/base-service.ts
+++ b/packages/exposure/src/services/base-service.ts
@@ -30,7 +30,7 @@ export interface ServiceOptions {
 }
 
 interface CuBuUrlOptions extends CustomerAndBusinessUnitOptions {
-  apiVersion: "v1" | "v2" | "v1/whitelabel" | "v3";
+  apiVersion: "v1" | "v2" | "v1/whitelabel" | "v2/whitelabel" | "v3";
 }
 
 export const errorMapper = err => {

--- a/packages/exposure/src/services/white-label-service.ts
+++ b/packages/exposure/src/services/white-label-service.ts
@@ -1,0 +1,26 @@
+import { BaseService, CustomerAndBusinessUnitOptions } from "./base-service";
+import { AppConfig } from "../models/app-config-model";
+
+export class WhiteLabelService extends BaseService {
+  public getAppConfig<App extends keyof AppConfig>({
+    customer,
+    businessUnit,
+    app
+  }: { app: App } & CustomerAndBusinessUnitOptions): Promise<AppConfig[App]> {
+    return this.get(`${this.cuBuUrl({ customer, businessUnit, apiVersion: "v2/whitelabel" })}/config/appConfig`).then(
+      data => {
+        const component = data.components[app][0];
+        const { assetSearchTypes, ...parameters } = component.parameters;
+        const images = component.presentation.fallback.images.reduce((map: Record<string, string>, { url, tags }) => {
+          map[tags[0]] = url;
+          return map;
+        }, {});
+
+        return {
+          ...parameters,
+          images
+        };
+      }
+    );
+  }
+}


### PR DESCRIPTION
The background to this addition is that for Samsung & LG we need to get appStoreUrl & appBundle ( for SSAI ) from the customer portal, this will be done runtime from the app.

We get into a bit of a weird territory here where we do whitelabel specific stuff in the exposure sdk, but the reason is that the whitelabel sdk has historically only been for the whitelabel api but now that that is sort-of part of exposure I don't know how to think about these things...

The exposure-sdk has also historically never really done any parsing as I do here, perhaps it would make more sense to:
a) Add the `getAppConfig()`but without any parsing
b) Do parsing in the whitelabel-sdk?