### PR TITLE
fix: handle debouncing as a loading state in useSearch hook

### DIFF
--- a/packages/whitelabel-react/demo/components/SearchInput.tsx
+++ b/packages/whitelabel-react/demo/components/SearchInput.tsx
@@ -4,10 +4,11 @@ import { useSearch } from "../../src/index";
 
 export default function SearchInput() {
   const [term, setTerm] = useState("");
-  const [assets] = useSearch(term);
+  const [assets, isLoading] = useSearch(term);
   return (
     <div>
       <input placeholder="Search" onChange={e => setTerm(e.target.value)} />
+      {isLoading && <p>Loading</p>}
       {assets?.map(a => (
         <Link key={a.assetId} to={`/asset/${a.assetId}`}>
           {a.title}

--- a/packages/whitelabel-react/src/hooks/useSearch.ts
+++ b/packages/whitelabel-react/src/hooks/useSearch.ts
@@ -14,6 +14,6 @@ export function useSearch(term: string, debounceTime = 300): TApiHook<WLAsset[]>
     if (!searchUrl || !debouncedTerm || term === "") return;
     return wlApi.search({ url: searchUrl, searchTerm: debouncedTerm });
   });
-  const isLoadingOrDebouncing = isLoading || term !== debouncedTerm;
-  return [data || null, term !== "" && isLoadingOrDebouncing, error];
+  const isLoadingOrDebouncing = term !== "" && (isLoading || term !== debouncedTerm);
+  return [data || null, isLoadingOrDebouncing, error];
 }


### PR DESCRIPTION
Realised that the debounce time in useSearch is not counted as isLoading, which is slightly annoying visually in the apps.