### PR TITLE
test: add simple integration tests

### DIFF
--- a/integration-tests/user-details.spec.ts
+++ b/integration-tests/user-details.spec.ts
@@ -1,0 +1,56 @@
+import { DeviceType, ExposureApi } from "../packages/exposure/src"
+
+let sessionToken: string | undefined = undefined;
+
+function authHeader() {
+  if (!sessionToken) return;
+  return {
+    Authorization: `Bearer ${sessionToken}`
+  }
+}
+
+const exposureApi = new ExposureApi({
+  customer: "BSCU",
+  businessUnit: "BSBU",
+  baseUrl: "https://exposure.api.redbee.dev",
+  authHeader
+})
+
+describe("userdetails", () => {
+  beforeAll(async () => {
+    const session = await exposureApi.authentication.login({
+      username: "simon.wallin1@mailinator.com",
+      password: "SimonTest",
+      device: {
+        type: DeviceType.WEB,
+        deviceId: "integrationTestDevice",
+        name: "integrationTestDevice"
+      }
+    });
+    sessionToken = session.sessionToken;
+  });
+  it("should persist user details", async () => {
+    const names = ["Simon1", "Simon2"];
+    const userDetails = await exposureApi.user.getUserDetails({});
+    const newName = names.find(n => n !== userDetails.displayName);
+    await exposureApi.user.updateUserDetails({ body: { displayName: newName } });
+    const updatedUserDetails = await exposureApi.user.getUserDetails({});
+    expect(updatedUserDetails.displayName).toBe(newName);
+  });
+  it("should persist user attributes", async () => {
+    const userDetails = await exposureApi.user.getUserDetails({});
+    const randomString = (Math.random() + 1).toString(36).substring(7);
+    const attributeToSet = userDetails.attributes.find(a => a.type === "string");
+    if (!attributeToSet) {
+      console.warn("Found no string attribute to modify");
+      return;
+    }
+    await exposureApi.user.setAttributes({
+      attributes: [{ attributeId: attributeToSet?.attributeId, value: randomString }]
+    })
+    const updatedUserDetails = await exposureApi.user.getUserDetails({});
+    expect(
+      updatedUserDetails.attributes.find(a => a.attributeId === attributeToSet.attributeId)?.value
+    ).toBe(randomString);
+  })
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const tsconfig = require("./packages/exposure/tsconfig.json");
+
+module.exports = {
+  roots: ["<rootDir>/integration-tests"],
+  transform: {
+    "^.+\\.ts?$": "ts-jest"
+  },
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.ts?$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  collectCoverage: true,
+  coverageReporters: ["text", "text-summary", "html"],
+  collectCoverageFrom: ["src/**/*.ts", "!**/node_modules/**"],
+  testEnvironment: "node",
+  globals: {
+    "ts-jest": {
+      tsconfig: {
+        ...tsconfig.compilerOptions,
+        esModuleInterop: true
+      }
+    }
+  }
+};


### PR DESCRIPTION
I usually have an uncommited test.ts file to run the sdk code for real when doing change. I thought that I might as well start commiting my test code as proper integration tests, so here are the last two things I tested.

I'm not thinking we should run these as a check on PR etc, but it's in my opinion nice to have whenever you want to test something e2e before creating a new release.