### PR TITLE
fix: remove intrusive console.warn

### DIFF
--- a/packages/whitelabel-react/src/RedBeeProvider.tsx
+++ b/packages/whitelabel-react/src/RedBeeProvider.tsx
@@ -181,7 +181,7 @@ export function RedBeeProvider({
     throw `Missing required prop in RedBeeProvider. You provided: exposureBaseUrl: ${exposureBaseUrl}, deviceGroup: ${deviceGroup}, device: ${device}`;
   }
   if (!storage) {
-    console.warn("not providing a storage module means no data will be persisted between sessions");
+    console.warn("[RedBeeProvider] not providing a storage module means no data will be persisted between sessions");
   }
   return (
     <InitialPropsProvider

--- a/packages/whitelabel-react/src/hooks/usePage.ts
+++ b/packages/whitelabel-react/src/hooks/usePage.ts
@@ -86,7 +86,6 @@ function getComponentConstructor(reference: WLReference) {
     case WLComponentType.TAG_TYPE:
       return WLCategoriesComponent;
     default:
-      console.warn(`unknown component type ${reference.type} ${reference.subType}`);
       return null;
   }
 }


### PR DESCRIPTION
console.warn is rendered in metro console with a complete stack trace. It's been annoying me for ages...