### PR TITLE
feat(EMP-19802): add model and interface for assetFeatures

### DIFF
--- a/packages/exposure/src/index.ts
+++ b/packages/exposure/src/index.ts
@@ -22,6 +22,7 @@ import { WhiteLabelService } from "./services/white-label-service";
 
 export { ILocalizedMetadata, ILocalizedMetadata as Localized } from "./interfaces/content/localized-metadata";
 export { ImageOrientation, ImageType, IImage, IImage as ImageModel } from "./interfaces/content/image";
+export { IAssetFeature, IAssetFeatureImage } from "./interfaces/content/asset-feature";
 export { IAssetResponse, IAssetResponse as AssetResponse } from "./interfaces/content/asset-response";
 export { IDeviceInfo, DeviceType } from "./interfaces/device";
 export {

--- a/packages/exposure/src/interfaces/content/asset-feature.ts
+++ b/packages/exposure/src/interfaces/content/asset-feature.ts
@@ -1,0 +1,9 @@
+export interface IAssetFeatureImage {
+  url: string;
+  selectors: string[];
+}
+
+export interface IAssetFeature {
+  id: string;
+  images: IAssetFeatureImage[];
+}

--- a/packages/exposure/src/models/asset-model.ts
+++ b/packages/exposure/src/models/asset-model.ts
@@ -7,6 +7,7 @@ import { IPublication } from "../interfaces/content/publication";
 import { localizedUtils } from "../utils/localized";
 import { WithLocalized } from "./localized-model";
 import { jsonProperty } from "../decorators/json-property";
+import { IAssetFeature } from "../interfaces/content/asset-feature";
 
 export enum mediumResBoundaries {
   lower = 500,
@@ -176,6 +177,8 @@ export class Asset extends WithLocalized {
   public subtitles: string[] = [];
   @jsonProperty({ type: String })
   public audioTracks: string[] = [];
+  @jsonProperty({ type: Object })
+  public assetFeatures?: IAssetFeature[];
 
   public series = () => {
     return this.tags.some(t => t.type === "series");

--- a/packages/whitelabel/src/interfaces/wl-carousel-item.ts
+++ b/packages/whitelabel/src/interfaces/wl-carousel-item.ts
@@ -3,7 +3,8 @@ import {
   Publication,
   ExternalReferences,
   ImageModel,
-  MarkerType
+  MarkerType,
+  IAssetFeature
 } from "@ericssonbroadcastservices/exposure-sdk";
 import { IWLAction } from "./wl-action";
 import { IWLAssetTag } from "./wl-tag";
@@ -88,4 +89,5 @@ export interface IWLCarouselItem {
   slugs?: string[];
   markerPoints?: IWLMarkerPoint[];
   seriesAssetAction?: IWLAction;
+  assetFeatures?: IAssetFeature[];
 }

--- a/packages/whitelabel/src/models/wl-asset.ts
+++ b/packages/whitelabel/src/models/wl-asset.ts
@@ -22,7 +22,8 @@ import {
   LoginResponse,
   ProductOffering,
   IImage,
-  publicationUtils
+  publicationUtils,
+  IAssetFeature
 } from "@ericssonbroadcastservices/exposure-sdk";
 import { EntitlementCase } from "../interfaces/entitlement-cases";
 import { WLAction } from "./wl-config";
@@ -109,6 +110,8 @@ export class WLAsset implements IWLCarouselItem {
   public markerPoints?: IWLMarkerPoint[];
   @jsonProperty()
   public seriesAssetAction?: WLAction;
+  @jsonProperty({ type: Object })
+  public assetFeatures?: IAssetFeature[];
 
   private getIdentifier = () => {
     return this.slugs?.length > 0 ? this.slugs[0] : this.assetId;


### PR DESCRIPTION
I'm not sure if what I'm doing is right, but it did the job when testing these changes with WLAPI.

[Here's a sample of the new data ](https://exposure.api.redbee.dev/v1/customer/BSCU/businessunit/BSBU/content/asset/b74e3719-3ef0-481a-8014-40fa7cea2402_82162E)(look for assetFeatures).