### PR TITLE
fix(content.getEpg): default daysForward and daysBackward to 0

### DIFF
--- a/packages/exposure/src/services/content-service.spec.ts
+++ b/packages/exposure/src/services/content-service.spec.ts
@@ -66,7 +66,7 @@ describe("Content service", () => {
       .get(
         `/v2/customer/CU/businessunit/BU/epg/123/date/${epgDateFormatter(
           new Date()
-        )}?daysBackward=1&daysForward=1&pageNumber=1&pageSize=500`
+        )}?daysBackward=0&daysForward=0&pageNumber=1&pageSize=500`
       )
       .reply(200, epgJson)
       .get(

--- a/packages/exposure/src/services/content-service.ts
+++ b/packages/exposure/src/services/content-service.ts
@@ -172,8 +172,8 @@ export class ContentService extends BaseService {
     date
   }: GetEpgOptions) {
     const requestQuery = {
-      daysBackward: daysBackward || 1,
-      daysForward: daysForward || 1,
+      daysBackward: daysBackward ?? 0,
+      daysForward: daysForward ?? 0,
       pageSize: pageSize || 500,
       pageNumber: pageNumber || 1
     };


### PR DESCRIPTION
The exposure swagger API describe them as:
"Days back compared to midnight of the date to get EPG for."
"Days forward compared to midnight of the date to get EPG for."

This is a bit vague/misleading.

I found that `0` for both
1. Fetches 24 h of programs (between midights before/after current time)
2. Gives the same results as not passing the param at all.

So I think this should be the default, because the current default tries to fetch 72h of programs, and you can't pass 0, because it will then default to `1` anyway.

Here's an example of the current way:
https://exposure.api.redbee.dev/v2/customer/Players/businessunit/SDKTesting/epg/902ba6bd_E5D874b/date/2023-05-11?daysBackward=1&daysForward=1&pageNumber=1&pageSize=500

(you can test/verify changing the params to 0 or removing them)

Because this test stream has so many programs the last result will be the current day at 17:30-17:35, so if you test after that you get no current/next program in the JS player program service (though you can fix it by setting a higher pageSize).

I could change the default back to 1 for backwards compatibility though. As long as it's `??` instead of `||`it works for me.