### PR TITLE
fix: remove stored item if set value is undefined

### DIFF
--- a/packages/exposure/src/utils/storage.ts
+++ b/packages/exposure/src/utils/storage.ts
@@ -2,6 +2,7 @@ const _storage = {};
 
 const store = (key: string, value: string): void => {
   if (typeof sessionStorage !== "undefined") {
+    if (!value) return sessionStorage.removeItem(key);
     sessionStorage.setItem(key, value);
   } else {
     _storage[key] = value;


### PR DESCRIPTION
This potentially fixes [this Sentry issue](https://red-bee-media.sentry.io/issues/3800926975/?project=4503981076447232&query=is%3Aunresolved+%21title%3A%22%2Asprites%2A%22&referrer=issue-stream&statsPeriod=90d&stream_index=2).