### PR TITLE
feat(EMP-20024): add optional playAsset params start,end

### DIFF
--- a/packages/exposure/src/services/entitlement-service.ts
+++ b/packages/exposure/src/services/entitlement-service.ts
@@ -45,6 +45,8 @@ interface PlayAssetOptions extends GetEntitlementForAssetOptions {
   supportedFormats?: TPlayFormat[];
   supportedDrms?: TPlayDrm[];
   materialProfile?: string;
+  start?: number;
+  end?: number;
 }
 
 export class EntitlementService extends BaseService {
@@ -123,7 +125,9 @@ export class EntitlementService extends BaseService {
     maxResolution,
     supportedFormats,
     supportedDrms,
-    materialProfile
+    materialProfile,
+    start,
+    end
   }: PlayAssetOptions): Promise<IPlay> {
     const queryParameters = new URLSearchParams(adParameters as Record<string, string>);
     if (audioOnly) {
@@ -143,6 +147,12 @@ export class EntitlementService extends BaseService {
     }
     if (materialProfile) {
       queryParameters.append("materialProfile", materialProfile);
+    }
+    if (start) {
+      queryParameters.append("start", `${start}`);
+    }
+    if (end) {
+      queryParameters.append("end", `${end}`);
     }
     return this.get(
       `${this.cuBuUrl({


### PR DESCRIPTION
See new params https://apidocs.tools.redbee.dev/#!/Entitlements/playV2

"Start/end time in number of seconds in the playback manifest."