### PR TITLE
feat(EMP-19789): Add support for language, expiration params for loginFirebase

### DIFF
--- a/packages/exposure/src/services/authentication-service.ts
+++ b/packages/exposure/src/services/authentication-service.ts
@@ -21,6 +21,8 @@ export interface LoginFireBaseOptions extends CustomerAndBusinessUnitOptions {
   accessToken: string;
   emailVerified: boolean;
   device: IDeviceInfo;
+  expiration?: string;
+  language?: string;
 }
 
 interface LoginByOauthTokenOptions extends CustomerAndBusinessUnitOptions {
@@ -79,26 +81,7 @@ export class AuthenticationService extends BaseService {
     return this.post(url, payload).then(data => deserialize(LoginResponse, data));
   }
 
-  public async loginFirebase({
-    username,
-    email,
-    displayName,
-    providerId,
-    accessToken,
-    customer,
-    businessUnit,
-    emailVerified,
-    device
-  }: LoginFireBaseOptions) {
-    const payload = {
-      username,
-      email,
-      displayName,
-      emailVerified,
-      providerId,
-      accessToken,
-      device
-    };
+  public async loginFirebase({ customer, businessUnit, ...payload }: LoginFireBaseOptions) {
     return this.post(
       `${this.cuBuUrl({
         customer,


### PR DESCRIPTION
EMP-19789 only specify to support `language`, but when I checked [swagger](https://exposure.api.redbee.dev/docs/index.html#/Authentication/loginFirebase) I also found that we don't support `expiration`, so I added it too as optional.

Also simplified the payload creation so instead of listing the props from the LoginFireBaseOptions type three times it uses rest parameter.