### PR TITLE
fix(changelog): TypeError Cannot read properties of null (reading 'charAt')

### DIFF
--- a/packages/conventional-changelog-redbeemedia/writer-opts.js
+++ b/packages/conventional-changelog-redbeemedia/writer-opts.js
@@ -75,11 +75,9 @@ function getWriterOpts () {
       }
 
       if (typeof commit.subject === 'string') {
-          // Remove github issue references
-          commit.subject = commit.subject.replace(/\(#([0-9]+)\)/g, '');
+        // Remove github issue references
+        commit.subject = capitalize(commit.subject.replace(/\(#([0-9]+)\)/g, ''))
       }
-
-      commit.subject = capitalize(commit.subject)
 
       // remove references that already appear in the subject
       commit.references = commit.references.filter(reference => {


### PR DESCRIPTION
We already had a type check for commit.subject, but this line wasn't included.

I also removed the semicolon (this file doesn't have it elsewhere) and removed one indentation level.