### PR TITLE
feat(changelog-generator): trim subject and remove extra blank lines

### DIFF
--- a/packages/conventional-changelog-redbeemedia/templates/header.hbs
+++ b/packages/conventional-changelog-redbeemedia/templates/header.hbs
@@ -1,3 +1,2 @@
 **v{{version}}**
-{{~#if date}} ({{date}})
-{{/if}}
+{{~#if date}} ({{date}}){{/if}}

--- a/packages/conventional-changelog-redbeemedia/templates/template.hbs
+++ b/packages/conventional-changelog-redbeemedia/templates/template.hbs
@@ -1,5 +1,4 @@
 {{> header}}
-
 {{#each commitGroups}}
 
 {{#if title}}
@@ -9,8 +8,6 @@
 {{#each commits}}
 {{> commit root=@root}}
 {{/each}}
-
 {{/each}}
 {{> footer}}
-
 

--- a/packages/conventional-changelog-redbeemedia/writer-opts.js
+++ b/packages/conventional-changelog-redbeemedia/writer-opts.js
@@ -76,7 +76,7 @@ function getWriterOpts () {
 
       if (typeof commit.subject === 'string') {
         // Remove github issue references
-        commit.subject = capitalize(commit.subject.replace(/\(#([0-9]+)\)/g, ''))
+        commit.subject = capitalize(commit.subject.replace(/\(#([0-9]+)\)/g, '').trim())
       }
 
       // remove references that already appear in the subject


### PR DESCRIPTION
I installed a markdown validator for vscode to catch broken links and similar, but it is also complaining about extra unnecessary spaces and lines that doesn't do anything. 

Before PR:
![Screenshot from 2023-06-28 17-32-24](https://github.com/EricssonBroadcastServices/javascript-sdk/assets/515120/90f29b0b-523c-43cc-a6c8-ebca3bc68064)

With PR:
![Screenshot from 2023-06-28 17-33-53](https://github.com/EricssonBroadcastServices/javascript-sdk/assets/515120/5046fcf4-eca2-4bf4-a0a6-28b6d704f4ae)
