### PR TITLE
feat: resolve epg component

### DIFF
--- a/packages/app-sdk/src/services/epg.spec.ts
+++ b/packages/app-sdk/src/services/epg.spec.ts
@@ -1,0 +1,30 @@
+import { DeviceGroup } from "../interfaces/device-group";
+import { IExpoureWLEpgComponent } from "../interfaces/exposure-wl-component";
+import { WhiteLabelService } from "./white-label-service";
+
+const service = new WhiteLabelService({
+  customer: "BSCU",
+  businessUnit: "BSBU",
+  baseUrl: "https://exposure.api.redbee.dev",
+  deviceGroup: DeviceGroup.WEB,
+  getAuthToken: () => Promise.resolve(undefined),
+  errorFactory: (response: Response) => {
+    return new Error(`HTTP Error: ${response.statusText} (${response.status}) for ${response.url}`);
+  }
+});
+
+describe("WhiteLabelServices", () => {
+  it("gets an epg component", async () => {
+    const epgComponent = await service.getComponentById<IExpoureWLEpgComponent>({
+      componentId: "e02ac2a8-bef0-49a3-9c60-3ed3c1c7e5db",
+      countryCode: "se"
+    });
+    const content = await service.getEpgContent(epgComponent);
+    content.forEach(epg => {
+      // TODO: use an isAsset util
+      expect(epg.channel.assetId).toEqual(expect.any(String));
+      // TODO: use an isProgramUtil
+      expect(epg.programs.length).toBeTruthy();
+    });
+  });
+});

--- a/packages/rbm-ott-sdk/generate.ts
+++ b/packages/rbm-ott-sdk/generate.ts
@@ -171,7 +171,8 @@ spec.components.schemas.Asset.required = ["assetId", "audioTracks", "changed", "
 spec.components.schemas.Program.required = ["endTime", "startTime"];
 spec.components.schemas.StoreAppStoreReference.required = ["productId"];
 spec.components.schemas.StoreGooglePlayReference.required = ["skuId"];
-
+spec.components.schemas.ChannelEPGResponse.required = ["programs", "channelId", "totalHitsAllChannels"]
+spec.components.schemas.ProgramResponse.required = ["asset", "assetId", "endTime", "startTime", "programId"];
 
 /* Fix types */
 spec.components.schemas.PaymentProvider = {"type": "string", "enum": ["stripe", "googleplay", "appstore", "external", "deny"]};

--- a/packages/rbm-ott-sdk/generated/data-contracts.ts
+++ b/packages/rbm-ott-sdk/generated/data-contracts.ts
@@ -390,10 +390,10 @@ export interface ChannelAsset {
 }
 
 export interface ChannelEPGResponse {
-  channelId?: string;
-  programs?: ProgramResponse[];
+  channelId: string;
+  programs: ProgramResponse[];
   /** This is the total number of hits for all channels, not only this. */
-  totalHitsAllChannels?: number;
+  totalHitsAllChannels: number;
 }
 
 export interface ChannelStatus {
@@ -1394,9 +1394,9 @@ export interface ProgramListEntryResponse {
 }
 
 export interface ProgramResponse {
-  asset?: Asset;
+  asset: Asset;
   /** The id of the asset this program is for. */
-  assetId?: string;
+  assetId: string;
   /**
    * If this program is currently published as blackout. This means any publication contains blackout, not global
    * blackout;
@@ -1412,10 +1412,10 @@ export interface ProgramResponse {
   channelId?: string;
   /** The date the program was created. */
   created?: string;
-  endTime?: string;
+  endTime: string;
   /** The id of the program. */
-  programId?: string;
-  startTime?: string;
+  programId: string;
+  startTime: string;
   /** If this asset is currently available as VOD. */
   vodAvailable?: boolean;
 }


### PR DESCRIPTION
More or less copy paste of the epg endpoint in whitelabelinternal api. 

One difference is that programs will now be proper programs rather than assets. I chose to do this because we will need reliable start/end times, which was previously added by wl-api.