### PR TITLE
fix: clamp bookmark progress between 0 and 100

### DIFF
--- a/packages/whitelabel-react/src/hooks/useBookmarks.ts
+++ b/packages/whitelabel-react/src/hooks/useBookmarks.ts
@@ -22,9 +22,6 @@ export function useBookmarkPercentage(assetId?: string): TApiHook<number> {
   const [bookmarks, bookmarksIsLoading, bookmarksError] = useBookmarks();
   const bookmark = bookmarks?.find(b => b.assetId === assetId);
   if (!bookmark || !asset) return [0, assetIsLoading || bookmarksIsLoading, assetError || bookmarksError];
-  return [
-    Math.round((((bookmark.lastViewedOffset as number) * 100) / asset.duration) as number),
-    assetIsLoading || bookmarksIsLoading,
-    assetError || bookmarksError
-  ];
+  const progress = Math.round((((bookmark.lastViewedOffset as number) * 100) / asset.duration) as number);
+  return [Math.max(0, Math.min(progress, 100)), assetIsLoading || bookmarksIsLoading, assetError || bookmarksError];
 }


### PR DESCRIPTION
This PR fixes an issue where progress for assets could have a progress greater than  100 which caused issues when displaying time left for assets in the apps.