### PR TITLE
fix: add asset remaining translation to useGetTimeLeft

### DIFF
--- a/packages/whitelabel-react/src/hooks/useProgramProgress.ts
+++ b/packages/whitelabel-react/src/hooks/useProgramProgress.ts
@@ -29,7 +29,12 @@ export function useGetTimeLeft({ percentageWatched, durationMs }: TimeLeftProps)
       minutes = `${time.minutes} ${translations?.getText(["DATES", "MINUTE"])}`;
     }
     if (hours || minutes) {
-      setTimeLeft(`${hours ? `${hours}, ` : ""}${minutes}`);
+      setTimeLeft(
+        `${hours ? `${hours}${minutes ? ", " : ""}` : ""}${minutes} ${translations?.getText([
+          "ASSETS",
+          "REMAINING"
+        ])}`.toLowerCase()
+      );
     }
   }, [durationMs, percentageWatched, translations]);
 


### PR DESCRIPTION
<img width="293" alt="Screenshot 2023-10-12 at 22 14 58" src="https://github.com/EricssonBroadcastServices/javascript-sdk/assets/6131004/e67e5cb3-d4d6-460b-b16f-1ad089c88088">
