### PR TITLE
fix: IFormat orgMediaLocator should be optional

### DIFF
--- a/packages/exposure/src/interfaces/entitlement/play.ts
+++ b/packages/exposure/src/interfaces/entitlement/play.ts
@@ -35,7 +35,7 @@ export class IDRM {
 export interface IFormat {
   format: FormatType;
   mediaLocator: string;
-  orgMediaLocator: string;
+  orgMediaLocator?: string;
   drm?: {
     [DRMType.FAIRPLAY]?: IDRM;
     [DRMType.PLAYREADY]?: IDRM;


### PR DESCRIPTION
IFormat is used with the portal player when you load from the "format".

In our demo player portal implementation we grab the format from the play response:
`const { formats } = await playResponse.json();`

In my brief testing this only contained: `{format: FormatType; mediaLocator: string}[]`, but TypeScript doesn't complain, because it doesn't have a type (it's `any`).

Originally reported to me by Quang, who ran into confusion about this.

