### PR TITLE
fix(rbm-ott-sdk): support array body param 

### DIFF
--- a/packages/rbm-ott-sdk/generated/UserService.ts
+++ b/packages/rbm-ott-sdk/generated/UserService.ts
@@ -536,9 +536,14 @@ export async function putUserAttributes({
   headers,
   ..._data
 }: {
+  list: {
+    /** id of the attribute */
+    attributeId: string;
+    value?: object;
+  }[];
   /** Optional headers */
   headers?: HeadersInit;
-} = {}) {
+}) {
   // @ts-ignore
   const ctx = (this.context || this) as ServiceContext;
   return request({
@@ -550,7 +555,7 @@ export async function putUserAttributes({
       ...Object.fromEntries(new Headers(headers))
     }),
     ctx,
-    body: _data
+    body: _data.list
   }).then(response => response.json() as Promise<UserDetailsResponse>);
 }
 

--- a/packages/rbm-ott-sdk/templates/procedure-call.ejs
+++ b/packages/rbm-ott-sdk/templates/procedure-call.ejs
@@ -36,6 +36,9 @@ function checkParamName(name, type) {
 function getRestParamsWithDefaults() {
   const defaults = Object.entries({ ...defaultParams, ...renamedParams });
   if (!defaults.length) {
+    if (body.schema?.type === "array") {   
+      return "_data.list"; 
+    }
     return "_data";
   }
   return `{ ${defaults.map(([k, v]) => `${k}: ${v}`).join(", ")}, ..._data }`;
@@ -74,12 +77,24 @@ const queryParams = (route.queryObjectSchema?.$parsed?.content || []).flatMap(({
   return [];
 });
 
-const bodyParams = Object.entries(body.schema?.properties || {}).map(([name, param]) => ({
-  name: checkParamName(name, "body"),
-  optional: !body.schema.required?.includes(name),
-  ...param,
-  type: param.$parsed?.content,
-}));
+let bodyParams = [];
+if (body.schema?.type === "object") {
+  bodyParams = Object.entries(body.schema?.properties || {}).map(([name, param]) => ({
+    name: checkParamName(name, "body"),
+    optional: !body.schema.required?.includes(name),
+    ...param,
+    type: param.$parsed?.content,
+  }));
+} else if (body.schema?.type === "array") {
+  bodyParams = [{
+    name: "list",
+    optional: !body.required,
+    type: body.type,
+  }]
+} else if (body.schema?.type) {
+  throw new Error(`Missing implementation for body param type "${body.schema?.type}"`);
+}
+
 
 const methodArgs = _.sortBy([
   ...pathParams,


### PR DESCRIPTION
Hard coded the param name for all endpoints with array as their body parameter directly, to be `list`. But there's just one route using this.

```ts
const list = [
  { attributeId: "1", value: {} }
];
putUserAttributes.call(ctx, { list });
```