### PR TITLE
fix(app-sdk): fix getLocalizedValue types

### DIFF
--- a/packages/app-sdk/src/utils/localization.ts
+++ b/packages/app-sdk/src/utils/localization.ts
@@ -38,16 +38,16 @@ export function getLocalizedValue<Key extends keyof Localized>(
   }
   const localeItem = localized.find(localizedItem => localizedItem.locale === locale);
   const value = localeItem?.[property];
-  if (!value || (Array.isArray(value) && !value?.length)) {
-    if (defaultLocale) {
-      return getLocalizedValue(localized, property, defaultLocale);
-    }
-    if (locale === localized[0].locale) {
-      return undefined;
-    }
-    return getLocalizedValue(localized, property, localized[0].locale);
+  if (value && (!Array.isArray(value) || value.length)) {
+    return value ? (value as Localized[Key]) : undefined;
   }
-  return value ? (value as Localized[Key]) : undefined;
+  if (defaultLocale) {
+    return getLocalizedValue(localized, property, defaultLocale);
+  }
+  if (locale === localized[0].locale) {
+    return undefined;
+  }
+  return getLocalizedValue(localized, property, localized[0].locale);
 }
 
 function sortByResolution(a: Image, b: Image) {


### PR DESCRIPTION
This code was correct, but when importing it to the js player, that environment complained about `Property 'length' does not exist on type 'string | Image | Image[]'` and `Cannot read properties of null (reading 'indexOf')`.

I'm not sure why the js-sdk environment wasn't complaining (it lints and builds fine here).

The second commit reverts the order because I thought with the change in the first commit it was even stranger to return the value at the bottom.