### PR TITLE
chore: upgrade prettier and apply formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/parser": "^5.7.0",
         "eslint": "^8.5.0",
         "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.27.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "husky": "^7.0.4",
@@ -24,7 +24,7 @@
         "jest": "^28.1.3",
         "lerna": "^7.3.1",
         "nock": "^13.1.3",
-        "prettier": "^2.5.1",
+        "prettier": "^3.2.4",
         "rimraf": "^5.0.0",
         "ts-jest": "^28.0.8",
         "typescript": "^4.5.4"
@@ -3905,6 +3905,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@remix-run/router": {
@@ -9528,21 +9540,30 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
       "dev": true,
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.6"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -17721,15 +17742,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -21083,6 +21104,22 @@
       "peerDependencies": {
         "@swc/core": "^1.2.147",
         "webpack": ">=2"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@typescript-eslint/parser": "^5.7.0",
     "eslint": "^8.5.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^7.0.4",
@@ -35,7 +35,7 @@
     "jest": "^28.1.3",
     "lerna": "^7.3.1",
     "nock": "^13.1.3",
-    "prettier": "^2.5.1",
+    "prettier": "^3.2.4",
     "rimraf": "^5.0.0",
     "ts-jest": "^28.0.8",
     "typescript": "^4.5.4"

--- a/packages/app-sdk/src/interfaces/device-group.ts
+++ b/packages/app-sdk/src/interfaces/device-group.ts
@@ -5,4 +5,4 @@ export const DeviceGroup = {
   TABLET: "TABLET",
   TV: "TV"
 } as const;
-export type DeviceGroup = typeof DeviceGroup[keyof typeof DeviceGroup];
+export type DeviceGroup = (typeof DeviceGroup)[keyof typeof DeviceGroup];

--- a/packages/app-sdk/src/interfaces/exposure-wl-action.ts
+++ b/packages/app-sdk/src/interfaces/exposure-wl-action.ts
@@ -4,7 +4,7 @@ export const WLActionTypes = {
   PlayAsset: "PlayAsset",
   NavigateToDetails: "NavigateToDetails"
 } as const;
-export type WLActionTypes = typeof WLActionTypes[keyof typeof WLActionTypes];
+export type WLActionTypes = (typeof WLActionTypes)[keyof typeof WLActionTypes];
 
 export const WLActionType = {
   ExternalLink: "ExternalLink",
@@ -12,13 +12,13 @@ export const WLActionType = {
   NavigateToDetails: "NavigateToDetails",
   PlayAsset: "PlayAsset"
 } as const;
-export type WLActionType = typeof WLActionType[keyof typeof WLActionType];
+export type WLActionType = (typeof WLActionType)[keyof typeof WLActionType];
 
 export const WLInternalActionType = {
   ExternalUrlAction: "ExternalUrlAction",
   BlockAction: "BlockAction"
 } as const;
-export type WLInternalActionType = typeof WLInternalActionType[keyof typeof WLInternalActionType];
+export type WLInternalActionType = (typeof WLInternalActionType)[keyof typeof WLInternalActionType];
 
 export interface IExposureWLAction {
   type: WLInternalActionType;

--- a/packages/app-sdk/src/interfaces/exposure-wl-component.ts
+++ b/packages/app-sdk/src/interfaces/exposure-wl-component.ts
@@ -24,13 +24,13 @@ export const WLCarouselAssetQueryTypes = {
   // SingleAsset is not currently used
   SINGLE_ASSET: "SingleAsset"
 } as const;
-export type WLCarouselAssetQueryTypes = typeof WLCarouselAssetQueryTypes[keyof typeof WLCarouselAssetQueryTypes];
+export type WLCarouselAssetQueryTypes = (typeof WLCarouselAssetQueryTypes)[keyof typeof WLCarouselAssetQueryTypes];
 
 export const WLHeroBannerItemType = {
   HEROBANNER_ITEM: "herobanner_item",
   VIDEO_HEROBANNER_ITEM: "video_herobanner_item"
 } as const;
-export type WLHeroBannerItemType = typeof WLHeroBannerItemType[keyof typeof WLHeroBannerItemType];
+export type WLHeroBannerItemType = (typeof WLHeroBannerItemType)[keyof typeof WLHeroBannerItemType];
 
 export const WLComponentType = {
   CAROUSEL: "carousel",
@@ -45,7 +45,7 @@ export const WLComponentType = {
   IFRAME: "iframe",
   TAG_TYPE: "tagtype"
 } as const;
-export type WLComponentType = typeof WLComponentType[keyof typeof WLComponentType];
+export type WLComponentType = (typeof WLComponentType)[keyof typeof WLComponentType];
 
 export const WLComponentSubType = {
   EPG: "Epg",
@@ -54,7 +54,7 @@ export const WLComponentSubType = {
   CONTINUE_WATCHING: "ContinueWatching",
   TAGS_QUERY: "TagsQuery"
 } as const;
-export type WLComponentSubType = typeof WLComponentSubType[keyof typeof WLComponentSubType];
+export type WLComponentSubType = (typeof WLComponentSubType)[keyof typeof WLComponentSubType];
 
 interface IExposureComponentParameters {
   assetSearchTypes?: string;

--- a/packages/app-sdk/src/interfaces/exposure-wl-reference.ts
+++ b/packages/app-sdk/src/interfaces/exposure-wl-reference.ts
@@ -6,21 +6,21 @@ export const CarouselLayout = {
   GRID: "grid",
   LIST: "list"
 } as const;
-export type CarouselLayout = typeof CarouselLayout[keyof typeof CarouselLayout];
+export type CarouselLayout = (typeof CarouselLayout)[keyof typeof CarouselLayout];
 
 export const PresentationImageOrientation = {
   LANDSCAPE: "landscape",
   PORTRAIT: "portrait"
 } as const;
 export type PresentationImageOrientation =
-  typeof PresentationImageOrientation[keyof typeof PresentationImageOrientation];
+  (typeof PresentationImageOrientation)[keyof typeof PresentationImageOrientation];
 
 export const CarouselDensity = {
   LOW: "LOW",
   MEDIUM: "MEDIUM",
   HIGH: "HIGH"
 } as const;
-export type CarouselDensity = typeof CarouselDensity[keyof typeof CarouselDensity];
+export type CarouselDensity = (typeof CarouselDensity)[keyof typeof CarouselDensity];
 
 export interface IExposureWLReference {
   name?: string;

--- a/packages/app-sdk/src/interfaces/image.ts
+++ b/packages/app-sdk/src/interfaces/image.ts
@@ -8,7 +8,7 @@ export const ImageType = {
   COVER: "cover",
   OTHER: "other"
 } as const;
-export type ImageType = typeof ImageType[keyof typeof ImageType];
+export type ImageType = (typeof ImageType)[keyof typeof ImageType];
 
 export interface IImage {
   url: string;

--- a/packages/exposure/src/interfaces/content/image.ts
+++ b/packages/exposure/src/interfaces/content/image.ts
@@ -3,7 +3,7 @@ export const ImageOrientation = {
   PORTRAIT: "PORTRAIT",
   SQUARE: "SQUARE"
 } as const;
-export type ImageOrientation = typeof ImageOrientation[keyof typeof ImageOrientation];
+export type ImageOrientation = (typeof ImageOrientation)[keyof typeof ImageOrientation];
 
 export enum ImageType {
   POSTER = "poster",

--- a/packages/exposure/src/interfaces/device.ts
+++ b/packages/exposure/src/interfaces/device.ts
@@ -7,7 +7,7 @@ export const DeviceType = {
   CONSOLE: "CONSOLE",
   STB: "STB"
 } as const;
-export type DeviceType = typeof DeviceType[keyof typeof DeviceType];
+export type DeviceType = (typeof DeviceType)[keyof typeof DeviceType];
 
 export interface IDeviceInfo {
   type: DeviceType;

--- a/packages/exposure/src/interfaces/entitlement/play.ts
+++ b/packages/exposure/src/interfaces/entitlement/play.ts
@@ -3,7 +3,7 @@ export const DRMType = {
   WIDEVINE: "com.widevine.alpha",
   FAIRPLAY: "com.apple.fps"
 } as const;
-export type DRMType = typeof DRMType[keyof typeof DRMType];
+export type DRMType = (typeof DRMType)[keyof typeof DRMType];
 
 export const FormatType = {
   DASH: "DASH",
@@ -12,20 +12,20 @@ export const FormatType = {
   MP4: "MP4",
   MP3: "MP3"
 } as const;
-export type FormatType = typeof FormatType[keyof typeof FormatType];
+export type FormatType = (typeof FormatType)[keyof typeof FormatType];
 
 export const Stitcher = {
   GENERIC: "GENERIC",
   INTERNAL: "INTERNAL",
   NOWTILUS: "NOWTILUS"
 } as const;
-export type Stitcher = typeof Stitcher[keyof typeof Stitcher];
+export type Stitcher = (typeof Stitcher)[keyof typeof Stitcher];
 
 export const AdClipCategory = {
   VOD: "vod",
   AD: "ad"
 } as const;
-export type AdClipCategory = typeof AdClipCategory[keyof typeof AdClipCategory];
+export type AdClipCategory = (typeof AdClipCategory)[keyof typeof AdClipCategory];
 
 export class IDRM {
   licenseServerUrl: string;

--- a/packages/exposure/src/models/asset-model.ts
+++ b/packages/exposure/src/models/asset-model.ts
@@ -97,7 +97,7 @@ export const MarkerType = {
   POINT: "POINT",
   CHAPTER: "CHAPTER"
 } as const;
-export type MarkerType = typeof MarkerType[keyof typeof MarkerType];
+export type MarkerType = (typeof MarkerType)[keyof typeof MarkerType];
 
 interface IEventTimes {
   startTime: string;


### PR DESCRIPTION
Prettier changed how to format cases like this, and the version "^2.5.1" seems to have resolved to a newer version for me so I got lint errors without applying these changes.

I also took the opportunity to upgrade prettier to the latest version.