### PR TITLE
chore(app-sdk): add some missing types

### DIFF
--- a/packages/app-sdk/src/services/carousels.spec.ts
+++ b/packages/app-sdk/src/services/carousels.spec.ts
@@ -18,7 +18,7 @@ function expectIsAssetList(assets: any[]) {
   });
 }
 
-let sessionToken;
+let sessionToken: string | undefined;
 
 const service = new WhiteLabelService({
   customer: "BSCU",
@@ -113,8 +113,8 @@ describe("get carousel assets", () => {
       countryCode: "SE"
     });
     expect(resolved.presentationParameters.backgroundImage).toBe(carouselRef.images?.[0]);
-    resolved.content?.forEach(caruoselItem => {
-      expect(caruoselItem.asset).toEqual(expectAsset());
+    resolved.content?.forEach(carouselItem => {
+      expect(carouselItem.asset).toEqual(expectAsset());
     });
   });
   it("gets a generated carousel by tagId", async () => {

--- a/packages/app-sdk/src/utils/wl-component.ts
+++ b/packages/app-sdk/src/utils/wl-component.ts
@@ -80,7 +80,7 @@ export function getTrailerAssetIdFromComponent(component: LocalizedWLComponent, 
   return localizedItem.trailerAssetId;
 }
 
-export function getTextComponentLexer(component: LocalizedWLComponent, language) {
+export function getTextComponentLexer(component: LocalizedWLComponent, language: string) {
   const body = getDescriptionFromWLComponent(component, language);
   return lexer(body);
 }

--- a/packages/app-sdk/src/utils/wl-translations.ts
+++ b/packages/app-sdk/src/utils/wl-translations.ts
@@ -1,5 +1,5 @@
 export class Translations {
-  constructor(public data) {}
+  constructor(public data: any) {}
   public getText = (key: string | (string | number)[]) => {
     if (typeof key === "string") {
       return this.data[key] || "";


### PR DESCRIPTION
More small fixes that I ran into because JS player wouldn't build (which is an indication that the tree shaking isn't working as I'm not importing these parts of app-sdk - although that's a separate issue).