### PR TITLE
chore(rbm-ott-sdk): declare no side effects (for webpack tree shaking)

### DIFF
--- a/packages/rbm-ott-sdk/package.json
+++ b/packages/rbm-ott-sdk/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "homepage": "https://github.com/EricssonBroadcastServices/javascript-sdk#readme",
   "main": "dist/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",


### PR DESCRIPTION
This doesn't seem to actually work, but better to set it anyway I think:
See https://webpack.js.org/configuration/optimization/#optimizationsideeffects