### PR TITLE
chore(app-sdk): internalIsWebPSupported crashes in jest

### DIFF
--- a/packages/app-sdk/src/utils/webp.ts
+++ b/packages/app-sdk/src/utils/webp.ts
@@ -32,7 +32,7 @@ function internalIsWebPSupported() {
     // Use canvas hack for webkit-based browsers
     // Kudos to Rui Marques: https://stackoverflow.com/a/27232658/7897049
     const e = window.document.createElement("canvas");
-    return e?.toDataURL ? e.toDataURL("image/webp").indexOf("data:image/webp") == 0 : false;
+    return e.toDataURL?.("image/webp")?.indexOf("data:image/webp") === 0;
   }
   return false;
 }

--- a/packages/whitelabel/src/utils/webp.ts
+++ b/packages/whitelabel/src/utils/webp.ts
@@ -32,7 +32,7 @@ function internalIsWebPSupported() {
     // Use canvas hack for webkit-based browsers
     // Kudos to Rui Marques: https://stackoverflow.com/a/27232658/7897049
     const e = window.document.createElement("canvas");
-    return e?.toDataURL ? e.toDataURL("image/webp").indexOf("data:image/webp") == 0 : false;
+    return e.toDataURL?.("image/webp")?.indexOf("data:image/webp") === 0;
   }
   return false;
 }


### PR DESCRIPTION
`e.toDataURL("image/webp")` returns null in jest:

![image](https://github.com/EricssonBroadcastServices/javascript-sdk/assets/515120/b6bd236a-8a24-4b03-ae06-40b50caea1aa)

There are checks in this method intended to keep this method from breaking in non-browser environments, but when setting up jest to mocks the dom, those are bypassed.

(I don't actually need this any more because of not using app-sdk in player any more, but still thought this would be good to add, and I added it for wl-sdk too, although I'm not sure we will drop that now immediately).