### PR TITLE
fix: use item.content.presentation in herobanner_items if available

### DIFF
--- a/packages/app-sdk/src/interfaces/exposure-wl-action.ts
+++ b/packages/app-sdk/src/interfaces/exposure-wl-action.ts
@@ -16,7 +16,8 @@ export type WLActionType = (typeof WLActionType)[keyof typeof WLActionType];
 
 export const WLInternalActionType = {
   ExternalUrlAction: "ExternalUrlAction",
-  BlockAction: "BlockAction"
+  BlockAction: "BlockAction",
+  AssetAction: "AssetAction"
 } as const;
 export type WLInternalActionType = (typeof WLInternalActionType)[keyof typeof WLInternalActionType];
 
@@ -29,4 +30,5 @@ export interface IExposureWLAction {
   localizedUrl?: {
     [key: string]: string;
   };
+  slugs?: string[];
 }

--- a/packages/app-sdk/src/interfaces/exposure-wl-component.ts
+++ b/packages/app-sdk/src/interfaces/exposure-wl-component.ts
@@ -93,8 +93,10 @@ export interface IExposureWLCategoriesComponent extends IExposureComponent {
 
 export interface IExposureWLHerobannerItem {
   appType: WLHeroBannerItemType;
+  appSubType?: string;
   presentation?: IExposureWLPresentation;
   content: {
+    type?: string;
     presentation?: IExposureWLPresentation;
   };
   actions?: { default: IExposureWLAction };

--- a/packages/app-sdk/src/utils/wl-component.spec.ts
+++ b/packages/app-sdk/src/utils/wl-component.spec.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { mockImageComponent, mockWLCarousel } from "../../test-utils/mock-components";
+import {
+  mockHerobannerItem,
+  mockHerobannerItemFromAsset,
+  mockImageComponent,
+  mockWLCarousel
+} from "../../test-utils/mock-components";
 import { WLComponentHelpers } from "./wl-component";
 
 describe("WLComponentHeloers", () => {
@@ -13,6 +18,19 @@ describe("WLComponentHeloers", () => {
     expect(WLComponentHelpers.getSubTitle(mockWLCarousel, "something unknown")).toBe("A bunch of animated shortfilms");
     expect(WLComponentHelpers.getSubTitle(mockWLCarousel, "sv")).toBe("A bunch of animated shortfilms");
   });
+
+  it("should use content.presentation for herobanner items, if available", () => {
+    expect(WLComponentHelpers.getTitle(mockHerobannerItemFromAsset, "it")).toBe("The Undertaker");
+    expect(WLComponentHelpers.getTrailerAssetId(mockHerobannerItemFromAsset, "it")).toBe(
+      "b7b6c343-90e9-40b4-be50-ef11f0149c91_AEBE0Fc"
+    );
+  });
+
+  it("should return standard presentation for items without presentation.content", () => {
+    expect(WLComponentHelpers.getTitle(mockHerobannerItem, "it")).toBe("just testing");
+    expect(WLComponentHelpers.getTrailerAssetId(mockHerobannerItem, "it")).toBe("123");
+  });
+
   it("should return a description", () => {
     expect(WLComponentHelpers.getDescription(mockImageComponent, "en")).toBe(
       "Everyone should be free to create 3D CG content, with free technical and creative production means and free access to markets."

--- a/packages/app-sdk/src/utils/wl-component.ts
+++ b/packages/app-sdk/src/utils/wl-component.ts
@@ -6,19 +6,24 @@ import { lexer } from "marked";
 
 type LocalizedWLComponent = IExposureComponent | IExposureWLHerobannerItem | IExposureWLMenuItem | IExposureWLConfig;
 
+function selectPresentation(component: LocalizedWLComponent) {
+  return (component as IExposureWLHerobannerItem).content?.presentation || component.presentation;
+}
+
 export function getLocalizedItemFromPresentation(presentation: IExposureWLPresentation, language: string) {
   if (!presentation.localized) return presentation.fallback;
   return presentation.localized[language] || presentation.fallback;
 }
 
 export function getTitleFromWLComponent(component: LocalizedWLComponent, language: string): string {
-  if (!component.presentation) return "";
-  const localizedItem = getLocalizedItemFromPresentation(component.presentation, language);
+  const presentation = selectPresentation(component);
+  if (!presentation) return "";
+  const localizedItem = getLocalizedItemFromPresentation(presentation, language);
   if (!localizedItem) {
     return "";
   }
   if (!localizedItem.title) {
-    return component.presentation.fallback?.title || "";
+    return presentation.fallback?.title || "";
   }
   return localizedItem.title;
 }
@@ -45,37 +50,41 @@ export function getImageByTagFromWLComponent(component: LocalizedWLComponent, ta
 }
 
 export function getDescriptionFromWLComponent(component: LocalizedWLComponent, language: string): string {
-  if (!component.presentation) return "";
-  const localizedItem = getLocalizedItemFromPresentation(component.presentation, language);
+  const presentation = selectPresentation(component);
+  if (!presentation) return "";
+  const localizedItem = getLocalizedItemFromPresentation(presentation, language);
   if (!localizedItem || !localizedItem.body) {
-    return component.presentation.fallback?.body || "";
+    return presentation.fallback?.body || "";
   }
   return localizedItem.body;
 }
 
 export function getSubTitleWLPresentation(component: LocalizedWLComponent, language: string): string {
-  if (!component.presentation) return "";
-  const localizedItem = getLocalizedItemFromPresentation(component.presentation, language);
+  const presentation = selectPresentation(component);
+  if (!presentation) return "";
+  const localizedItem = getLocalizedItemFromPresentation(presentation, language);
   if (!localizedItem || !localizedItem.subTitle) {
-    return component.presentation.fallback?.subTitle || "";
+    return presentation.fallback?.subTitle || "";
   }
   return localizedItem.subTitle;
 }
 
 export function getIframeFromWLPresentation(component: LocalizedWLComponent, language: string) {
-  if (!component.presentation) return null;
-  const localizedItem = getLocalizedItemFromPresentation(component.presentation, language);
+  const presentation = selectPresentation(component);
+  if (!presentation) return null;
+  const localizedItem = getLocalizedItemFromPresentation(presentation, language);
   if (!localizedItem || !localizedItem.iframe) {
-    return component.presentation.fallback?.iframe || null;
+    return presentation.fallback?.iframe || null;
   }
   return localizedItem.iframe;
 }
 
 export function getTrailerAssetIdFromComponent(component: LocalizedWLComponent, language: string) {
-  if (!component.presentation) return null;
-  const localizedItem = getLocalizedItemFromPresentation(component.presentation, language);
+  const presentation = selectPresentation(component);
+  if (!presentation) return null;
+  const localizedItem = getLocalizedItemFromPresentation(presentation, language);
   if (!localizedItem || !localizedItem.trailerAssetId) {
-    return component.presentation.fallback?.trailerAssetId || null;
+    return presentation.fallback?.trailerAssetId || null;
   }
   return localizedItem.trailerAssetId;
 }

--- a/packages/app-sdk/test-utils/mock-components.ts
+++ b/packages/app-sdk/test-utils/mock-components.ts
@@ -1,4 +1,8 @@
-import { IExposureWLCarousel, IExposureWLImageComponent } from "../src/interfaces/exposure-wl-component";
+import {
+  IExposureWLCarousel,
+  IExposureWLHerobannerItem,
+  IExposureWLImageComponent
+} from "../src/interfaces/exposure-wl-component";
 
 export const mockWLCarousel: IExposureWLCarousel = {
   id: "c225a4a3-14a7-4c90-99e8-74d958236502",
@@ -131,5 +135,103 @@ export const mockEpgCarousel: IExposureWLCarousel = {
   },
   parameters: {
     assetSearchTypes: "MOVIE,TV_SHOW,EPISODE,TV_CHANNEL,LIVE_EVENT,EVENT"
+  }
+};
+
+export const mockHerobannerItemFromAsset: IExposureWLHerobannerItem = {
+  appType: "herobanner_item",
+  appSubType: "Asset",
+  presentation: {
+    fallback: {
+      body: "   "
+    },
+    localized: {
+      it: {
+        body: "   "
+      }
+    }
+  },
+  actions: {
+    default: {
+      type: "AssetAction",
+      verb: "NavigateToDetails",
+      assetId: "f8c17c6d-d05e-4717-a185-7c625a8dc661_AEBE0Fc",
+      slugs: ["the-undertaker"]
+    }
+  },
+  content: {
+    type: "PresentationFromAsset",
+    presentation: {
+      fallback: {
+        title: "The Undertaker",
+        body: "   ",
+        images: [
+          {
+            url: "https://AEBE0Fc-az-westeurope-fsly.cdn.redbee.live/imagescaler002/ixmedia/assets/f8c17c6d-d05e-4717-a185-7c625a8dc661_AEBE0Fc/posters/dc28986b1d9a4289b0a12f6f6c5cf041/dc28986b1d9a4289b0a12f6f6c5cf041.jpg",
+            orientation: "LANDSCAPE",
+            tags: ["cover"],
+            height: 1080,
+            width: 1920
+          },
+          {
+            url: "https://AEBE0Fc-az-westeurope-fsly.cdn.redbee.live/imagescaler002/ixmedia/assets/f8c17c6d-d05e-4717-a185-7c625a8dc661_AEBE0Fc/posters/6fa971becf119299f1109d4ed3b8ae4b/6fa971becf119299f1109d4ed3b8ae4b.jpg",
+            orientation: "PORTRAIT",
+            tags: ["cover"],
+            height: 1200,
+            width: 800
+          }
+        ],
+        trailerAssetId: "b7b6c343-90e9-40b4-be50-ef11f0149c91_AEBE0Fc"
+      },
+      localized: {
+        it: {
+          title: "The Undertaker",
+          body: "   ",
+          images: [
+            {
+              url: "https://AEBE0Fc-az-westeurope-fsly.cdn.redbee.live/imagescaler002/ixmedia/assets/f8c17c6d-d05e-4717-a185-7c625a8dc661_AEBE0Fc/posters/6fa971becf119299f1109d4ed3b8ae4b/6fa971becf119299f1109d4ed3b8ae4b.jpg",
+              orientation: "PORTRAIT",
+              tags: ["cover"],
+              height: 1200,
+              width: 800
+            },
+            {
+              url: "https://AEBE0Fc-az-westeurope-fsly.cdn.redbee.live/imagescaler002/ixmedia/assets/f8c17c6d-d05e-4717-a185-7c625a8dc661_AEBE0Fc/posters/dc28986b1d9a4289b0a12f6f6c5cf041/dc28986b1d9a4289b0a12f6f6c5cf041.jpg",
+              orientation: "LANDSCAPE",
+              tags: ["cover"],
+              height: 1080,
+              width: 1920
+            }
+          ],
+          trailerAssetId: "b7b6c343-90e9-40b4-be50-ef11f0149c91_AEBE0Fc"
+        }
+      }
+    }
+  }
+};
+
+export const mockHerobannerItem: IExposureWLHerobannerItem = {
+  appType: "herobanner_item",
+  appSubType: "Asset",
+  presentation: {
+    fallback: {
+      body: "   "
+    },
+    localized: {
+      it: {
+        body: "   ",
+        title: "just testing",
+        trailerAssetId: "123"
+      }
+    }
+  },
+  content: {},
+  actions: {
+    default: {
+      type: "AssetAction",
+      verb: "NavigateToDetails",
+      assetId: "f8c17c6d-d05e-4717-a185-7c625a8dc661_AEBE0Fc",
+      slugs: ["the-undertaker"]
+    }
   }
 };


### PR DESCRIPTION
In the wl-api we are currently selection content.presentation if available. We need to do it here as well for asset derived herobanners to work.