### PR TITLE
feat: useEPG, useEPGEntry, useEPGProgram

### DIFF
--- a/packages/app-sdk-react/demo/components/EPGComponent/EPGComponent.tsx
+++ b/packages/app-sdk-react/demo/components/EPGComponent/EPGComponent.tsx
@@ -1,51 +1,40 @@
-import {
-  AssetHelpers,
-  EPGComponentEntry,
-  EPGHelpers,
-  ResolvedComponent,
-  WLComponentHelpers
-} from "@ericssonbroadcastservices/app-sdk";
-import React, { useMemo } from "react";
-import { useSelectedLanguage } from "../../../src";
+import { EPGComponentEntry, ResolvedComponent } from "@ericssonbroadcastservices/app-sdk";
+import React from "react";
+import { useEPG, useEPGEntry, useEPGProgram } from "../../../src";
 import "./epg.css";
 import { Link } from "react-router-dom";
+import { ProgramResponse } from "@ericssonbroadcastservices/rbm-ott-sdk";
+
+function EPGCardProgram({ program }: { program: ProgramResponse }) {
+  const { time, title, isLive } = useEPGProgram(program);
+  return (
+    <p key={program.assetId}>
+      {isLive && <span className="live-badge">LIVE</span>}
+      {`${title} - ${time}`}
+    </p>
+  );
+}
 
 function EpgCard(channelEntry: EPGComponentEntry) {
-  const locale = useSelectedLanguage();
-  const channelLogo = useMemo(() => {
-    return AssetHelpers.getScaledImage({
-      width: 150,
-      asset: channelEntry.channel,
-      imageType: "logo",
-      locale,
-      orientation: "LANDSCAPE"
-    });
-  }, [channelEntry.channel]);
-  const onGoingProgramsNextHours = useMemo(() => {
-    return EPGHelpers.findCurrentAndUpcomingProgramsByHour(channelEntry.programs, new Date());
-  }, []);
+  const { image, programs, progress } = useEPGEntry(channelEntry, new Date(), {
+    width: 150,
+    imageOrientation: "LANDSCAPE"
+  });
   return (
     <Link to={`/asset/${channelEntry.channel.assetId}`} className="epg-card">
-      <h4>{AssetHelpers.getTitle(channelEntry.channel, locale)}</h4>
-      <img src={channelLogo} />
-      {onGoingProgramsNextHours.map(program => {
-        const isLive = EPGHelpers.isProgramLive(program);
-        return (
-          <p key={program.assetId}>
-            {isLive && <span className="live-badge">LIVE</span>}
-            {`${AssetHelpers.getTitle(program.asset, locale)} - ${EPGHelpers.getProgramTimeSlotString(program)}`}
-          </p>
-        );
-      })}
+      <img src={image} />
+      {programs.map(program => (
+        <EPGCardProgram key={program.assetId} program={program} />
+      ))}
     </Link>
   );
 }
 
-export const EPGComponent = ({ component, content }: ResolvedComponent<"epg">) => {
-  const locale = useSelectedLanguage();
+export const EPGComponent = (props: ResolvedComponent<"epg">) => {
+  const { title, content } = useEPG(props);
   return (
     <div className="epg-container">
-      <h3>{WLComponentHelpers.getTitle(component, locale)}</h3>
+      <h3>{title}</h3>
       <div className="epg-content-container">
         {content.map(channelEntry => {
           return <EpgCard key={channelEntry.channel.assetId} {...channelEntry} />;

--- a/packages/app-sdk-react/src/hooks/useEPG.ts
+++ b/packages/app-sdk-react/src/hooks/useEPG.ts
@@ -1,0 +1,27 @@
+import {
+  EpgComponentContent,
+  ResolvedComponent,
+  WLComponentHelpers,
+  getLocalizedValue
+} from "@ericssonbroadcastservices/app-sdk";
+import { useLanguage } from "./useSelectedLanguage";
+import { useMemo } from "react";
+
+export function useEPG(epg: ResolvedComponent<"epg">): { title: string; content: EpgComponentContent } {
+  const { language, defaultLanguage } = useLanguage();
+
+  const sortedContent = useMemo(
+    () =>
+      epg.content.sort(({ channel: channelA }, { channel: channelB }) => {
+        const sortingTitelA = getLocalizedValue(channelA.localized, "sortingTitle", language, defaultLanguage);
+        const sortingTitelB = getLocalizedValue(channelB.localized, "sortingTitle", language, defaultLanguage);
+        if (!sortingTitelA || !sortingTitelB) {
+          return 0;
+        }
+        return sortingTitelA.localeCompare(sortingTitelB);
+      }),
+    [epg.content, language, defaultLanguage]
+  );
+
+  return { title: WLComponentHelpers.getTitle(epg.component, language), content: sortedContent };
+}

--- a/packages/app-sdk-react/src/hooks/useEPGEntry.ts
+++ b/packages/app-sdk-react/src/hooks/useEPGEntry.ts
@@ -1,0 +1,47 @@
+import { AssetHelpers, EPGComponentEntry, EPGHelpers } from "@ericssonbroadcastservices/app-sdk";
+import { ImageOrientation } from "@ericssonbroadcastservices/rbm-ott-sdk";
+import { useLanguage } from "./useSelectedLanguage";
+import { useMemo } from "react";
+
+export function useEPGEntry(
+  entry: EPGComponentEntry,
+  time: Date,
+  {
+    width,
+    imageOrientation
+  }: {
+    width: number;
+    imageOrientation: ImageOrientation;
+  }
+) {
+  const language = useLanguage();
+
+  const image =
+    AssetHelpers.getScaledImage({
+      orientation: imageOrientation,
+      width,
+      asset: entry.channel,
+      imageType: "logo",
+      ...language
+    }) ||
+    AssetHelpers.getScaledImage({
+      orientation: imageOrientation,
+      width,
+      asset: entry.channel,
+      imageType: "cover",
+      ...language
+    });
+
+  const programs = useMemo(
+    () => EPGHelpers.findCurrentAndUpcomingProgramsByHour(entry.programs, time),
+    [entry.programs, time]
+  );
+
+  const progress = EPGHelpers.getCurrentProgramProgress(programs);
+
+  return {
+    image,
+    programs,
+    progress
+  };
+}

--- a/packages/app-sdk-react/src/hooks/useEPGProgram.ts
+++ b/packages/app-sdk-react/src/hooks/useEPGProgram.ts
@@ -1,0 +1,15 @@
+import { EPGHelpers, getTitleFromAsset } from "@ericssonbroadcastservices/app-sdk";
+import { ProgramResponse } from "@ericssonbroadcastservices/rbm-ott-sdk";
+import { useLanguage } from "./useSelectedLanguage";
+
+export function useEPGProgram(program: ProgramResponse) {
+  const language = useLanguage();
+  const title = getTitleFromAsset(program.asset, language) ?? "";
+  const time = EPGHelpers.getProgramTimeSlotString(program) ?? "";
+  const isLive = EPGHelpers.isProgramLive(program);
+  return {
+    title,
+    time,
+    isLive
+  };
+}

--- a/packages/app-sdk-react/src/index.ts
+++ b/packages/app-sdk-react/src/index.ts
@@ -39,4 +39,7 @@ export * from "./hooks/useAssetDisplay";
 export * from "./hooks/useSetNewPassword";
 export * from "./hooks/useConfirmSignup";
 export * from "./hooks/useAppError";
+export * from "./hooks/useEPG";
+export * from "./hooks/useEPGEntry";
+export * from "./hooks/useEPGProgram";
 export type { TApiHook, TApiMutation } from "./types/type.apiHook";

--- a/packages/app-sdk/src/services/methods/get-epg-content.ts
+++ b/packages/app-sdk/src/services/methods/get-epg-content.ts
@@ -25,8 +25,5 @@ export async function getEpgContent(
       return null;
     }
   });
-  return (await Promise.all(channels)).filter(c => c !== null) as {
-    channel: Asset;
-    programs: ProgramResponse[];
-  }[];
+  return (await Promise.all(channels)).filter((c): c is { channel: Asset; programs: ProgramResponse[] } => c !== null);
 }


### PR DESCRIPTION
I noticed that the order of channels of off in the rn-tv app and that lead me down a goose chase to find the cause.

Turns out that the wl-api manually does sorting and that the exposure API _can't_ do that as is. Since the sorting title is a localized value we need to do it in the react package since that is where we have access to the languages.

There were also other inconsistencies like which images to use, how to display time etc. so I decided to add hooks for all three cases. EPG, EPGCard & EPGProgram