### PR TITLE
feat: require min 4 assets in the tag carousel on the asset page

### DIFF
--- a/packages/app-sdk/src/services/methods/get-asset-page.ts
+++ b/packages/app-sdk/src/services/methods/get-asset-page.ts
@@ -81,6 +81,11 @@ export async function getAssetPage(
           excludedAssetId: asset.assetId,
           locale,
           onlyIncludePlayableAssets: useOnlyPlayableAssets
+        }).then(resolvedComponent => {
+          if (resolvedComponent.content.length < 4) {
+            throw new Error(`Tag ${tagId} contained less than 4 items`);
+          }
+          return resolvedComponent;
         })
       );
     });


### PR DESCRIPTION
This aligns the behavior with wl-api.