### PR TITLE
feat: enable push next program

### DIFF
--- a/packages/app-sdk-react/src/hooks/usePushNextContentData.ts
+++ b/packages/app-sdk-react/src/hooks/usePushNextContentData.ts
@@ -6,8 +6,8 @@ import { PushNextContent } from "@ericssonbroadcastservices/app-sdk";
 import { useAppError } from "./useAppError";
 
 export function usePushNextContentData(
-  assetId?: string,
-  pushNextProgram?: boolean
+  assetId: string | undefined,
+  pushNextProgram = true
 ): TApiHook<{ upNext?: Asset; recommendations: Asset[] | null }> {
   const { customer, businessUnit, appService } = useRedBeeState();
   const [pushNextContent, setPushNextContent] = useState<PushNextContent | null>(null);
@@ -15,7 +15,7 @@ export function usePushNextContentData(
   useEffect(() => {
     if (assetId) {
       appService
-        .getPushNextContentData({ assetId, pushNextProgram: !!pushNextProgram })
+        .getPushNextContentData({ assetId, pushNextProgram: pushNextProgram })
         .then(pnc => {
           setPushNextContent(pnc);
         })


### PR DESCRIPTION
This makes it possible for the apps to decide if it should use pnc on catchup. 

I defaulted it to true, since that makes sense given our current customers.