### PR TITLE
feat: add possibility to select image type on asset details

### DIFF
--- a/packages/app-sdk-react/src/hooks/useAssetDisplay.ts
+++ b/packages/app-sdk-react/src/hooks/useAssetDisplay.ts
@@ -21,6 +21,7 @@ type UseAssetOptions = {
   height?: number;
   imageFormat?: ImageFormat;
   paymentProvider?: PaymentProvider;
+  imageType?: string;
 };
 
 export function useAssetDisplayCollection(asset: Asset, options: UseAssetOptions) {
@@ -143,7 +144,7 @@ function useAssetDisplayDefaults(asset: Asset, options: UseAssetOptions) {
     asset,
     width,
     height,
-    imageType: "cover",
+    imageType: options.imageType ?? "cover",
     format: imageFormat,
     orientation: ImageOrientation.LANDSCAPE,
     language,

--- a/packages/app-sdk-react/src/hooks/useAssetDisplay.ts
+++ b/packages/app-sdk-react/src/hooks/useAssetDisplay.ts
@@ -22,6 +22,7 @@ type UseAssetOptions = {
   imageFormat?: ImageFormat;
   paymentProvider?: PaymentProvider;
   imageType?: string;
+  imageTypeFallback?: string;
 };
 
 export function useAssetDisplayCollection(asset: Asset, options: UseAssetOptions) {
@@ -145,6 +146,7 @@ function useAssetDisplayDefaults(asset: Asset, options: UseAssetOptions) {
     width,
     height,
     imageType: options.imageType ?? "cover",
+    imageTypeFallback: options.imageTypeFallback ?? "cover",
     format: imageFormat,
     orientation: ImageOrientation.LANDSCAPE,
     language,

--- a/packages/app-sdk/src/utils/asset.ts
+++ b/packages/app-sdk/src/utils/asset.ts
@@ -81,10 +81,18 @@ export function getLocalizedAssetImage(
   asset: Asset,
   imageOrientation: ImageOrientation,
   imageType: string,
+  imageTypeFallback: string,
   locale: string,
   defaultLocale?: string
 ) {
-  return getLocalizedImageByType(asset.localized, imageOrientation, imageType, locale, defaultLocale);
+  return getLocalizedImageByType(
+    asset.localized,
+    imageOrientation,
+    imageType,
+    imageTypeFallback,
+    locale,
+    defaultLocale
+  );
 }
 
 export function getScaledAssetImage({
@@ -93,6 +101,7 @@ export function getScaledAssetImage({
   format,
   asset,
   imageType,
+  imageTypeFallback,
   orientation,
   language,
   defaultLanguage
@@ -102,11 +111,12 @@ export function getScaledAssetImage({
   format?: ImageFormat;
   asset: Asset;
   imageType: string;
+  imageTypeFallback: string;
   orientation: ImageOrientation;
   language: string;
   defaultLanguage?: string;
 }) {
-  const image = getLocalizedAssetImage(asset, orientation, imageType, language, defaultLanguage);
+  const image = getLocalizedAssetImage(asset, orientation, imageType, imageTypeFallback, language, defaultLanguage);
   if (!image?.url) return;
   return fit(image.url, { w: width, h: height, format });
 }

--- a/packages/app-sdk/src/utils/asset.ts
+++ b/packages/app-sdk/src/utils/asset.ts
@@ -81,16 +81,16 @@ export function getLocalizedAssetImage(
   asset: Asset,
   imageOrientation: ImageOrientation,
   imageType: string,
-  imageTypeFallback: string,
   locale: string,
+  imageTypeFallback?: string,
   defaultLocale?: string
 ) {
   return getLocalizedImageByType(
     asset.localized,
     imageOrientation,
     imageType,
-    imageTypeFallback,
     locale,
+    imageTypeFallback,
     defaultLocale
   );
 }
@@ -111,12 +111,12 @@ export function getScaledAssetImage({
   format?: ImageFormat;
   asset: Asset;
   imageType: string;
-  imageTypeFallback: string;
   orientation: ImageOrientation;
   language: string;
+  imageTypeFallback?: string;
   defaultLanguage?: string;
 }) {
-  const image = getLocalizedAssetImage(asset, orientation, imageType, imageTypeFallback, language, defaultLanguage);
+  const image = getLocalizedAssetImage(asset, orientation, imageType, language, imageTypeFallback, defaultLanguage);
   if (!image?.url) return;
   return fit(image.url, { w: width, h: height, format });
 }

--- a/packages/app-sdk/src/utils/localization.ts
+++ b/packages/app-sdk/src/utils/localization.ts
@@ -71,9 +71,15 @@ export function getLocalizedImageByType(
   }
 
   const imagesByCorrectOrientation = allImages.filter(i => i.orientation === orientation.toUpperCase());
-  const imagesByCorrectType = imagesByCorrectOrientation.filter(i => i.type === imageType);
-  if (imagesByCorrectType.length > 0) {
-    return imagesByCorrectType[0];
+  const imageByCorrectType = imagesByCorrectOrientation.find(i => i.type === imageType);
+  if (imageByCorrectType) {
+    return imageByCorrectType;
+  }
+  if (imageType !== "cover") {
+    const imageByCoverType = imagesByCorrectOrientation.find(i => i.type === "cover");
+    if (imageByCoverType) {
+      return imageByCoverType;
+    }
   }
   if (imagesByCorrectOrientation.length > 0) {
     return imagesByCorrectOrientation[0];

--- a/packages/app-sdk/src/utils/localization.ts
+++ b/packages/app-sdk/src/utils/localization.ts
@@ -58,6 +58,7 @@ export function getLocalizedImageByType(
   localized: Localized[],
   orientation: ImageOrientation,
   imageType: string,
+  imageTypeFallback: string,
   locale: string,
   defaultLocale?: string
 ): Image | undefined {
@@ -75,10 +76,10 @@ export function getLocalizedImageByType(
   if (imageByCorrectType) {
     return imageByCorrectType;
   }
-  if (imageType !== "cover") {
-    const imageByCoverType = imagesByCorrectOrientation.find(i => i.type === "cover");
-    if (imageByCoverType) {
-      return imageByCoverType;
+  if (imageType !== imageTypeFallback) {
+    const imageByFallbackType = imagesByCorrectOrientation.find(i => i.type === imageTypeFallback);
+    if (imageByFallbackType) {
+      return imageByFallbackType;
     }
   }
   if (imagesByCorrectOrientation.length > 0) {

--- a/packages/app-sdk/src/utils/localization.ts
+++ b/packages/app-sdk/src/utils/localization.ts
@@ -58,8 +58,8 @@ export function getLocalizedImageByType(
   localized: Localized[],
   orientation: ImageOrientation,
   imageType: string,
-  imageTypeFallback: string,
   locale: string,
+  imageTypeFallback?: string,
   defaultLocale?: string
 ): Image | undefined {
   if (!localized.length) {
@@ -76,7 +76,7 @@ export function getLocalizedImageByType(
   if (imageByCorrectType) {
     return imageByCorrectType;
   }
-  if (imageType !== imageTypeFallback) {
+  if (imageTypeFallback && imageType !== imageTypeFallback) {
     const imageByFallbackType = imagesByCorrectOrientation.find(i => i.type === imageTypeFallback);
     if (imageByFallbackType) {
       return imageByFallbackType;


### PR DESCRIPTION
Addition of the possibility to indicate the imageType on the details page of the asset, while keeping the "cover" type as the default and the existing logic as a fallback.